### PR TITLE
Only allow integers for cloud events

### DIFF
--- a/apps/cloud/src/events/put.ts
+++ b/apps/cloud/src/events/put.ts
@@ -1,4 +1,4 @@
-import { PutObjectCommand } from "@aws-sdk/client-s3";
+import { DeleteObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { Space } from "@cloud/classes/space";
 import { Storage } from "@cloud/classes/storage";
@@ -14,6 +14,13 @@ export async function putBlob(
   const { data: payload, error: parseError } = ZCloudPutBlob.safeParse(data);
   if (parseError || !payload)
     return { error: parseError.message || "Failed to validate payload" };
+
+  await durableObject.s3.send(
+    new DeleteObjectCommand({
+      Bucket: durableObject.bucket,
+      Key: `${durableObject.id}/${payload.key}`,
+    }),
+  );
 
   const { error, space: spaceStats } = await consumeSpace(
     storage,

--- a/apps/cloud/src/events/put.ts
+++ b/apps/cloud/src/events/put.ts
@@ -1,4 +1,4 @@
-import { DeleteObjectCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { PutObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 import { Space } from "@cloud/classes/space";
 import { Storage } from "@cloud/classes/storage";
@@ -14,13 +14,6 @@ export async function putBlob(
   const { data: payload, error: parseError } = ZCloudPutBlob.safeParse(data);
   if (parseError || !payload)
     return { error: parseError.message || "Failed to validate payload" };
-
-  await durableObject.s3.send(
-    new DeleteObjectCommand({
-      Bucket: durableObject.bucket,
-      Key: `${durableObject.id}/${payload.key}`,
-    }),
-  );
 
   const { error, space: spaceStats } = await consumeSpace(
     storage,

--- a/libs/schemas/src/cloud.ts
+++ b/libs/schemas/src/cloud.ts
@@ -18,8 +18,8 @@ export const ZCloudPutBlob = ZCloudBase.merge(
 export const ZCloudGetBlob = ZCloudBase.merge(
   z.object({
     key: ZKey,
-    offset: z.number().int().min(0).optional(),
-    length: z.number().int().min(0).optional(),
+    offset: z.number().int().optional(),
+    length: z.number().int().optional(),
   }),
 );
 

--- a/libs/schemas/src/cloud.ts
+++ b/libs/schemas/src/cloud.ts
@@ -11,15 +11,15 @@ export const ZCloudBase = z.object({
 export const ZCloudPutBlob = ZCloudBase.merge(
   z.object({
     key: ZKey,
-    size: z.number().min(0),
+    size: z.number().int().min(0),
   }),
 );
 
 export const ZCloudGetBlob = ZCloudBase.merge(
   z.object({
     key: ZKey,
-    offset: z.number().optional(),
-    length: z.number().optional(),
+    offset: z.number().int().min(0).optional(),
+    length: z.number().int().min(0).optional(),
   }),
 );
 


### PR DESCRIPTION
Right now, a decimal could be passed, which would probably not work with the usage calculation logic.