### PR TITLE
refactor(desktop): improve configuration of sftp provider

### DIFF
--- a/apps/desktop/public/locales/en/vault.json
+++ b/apps/desktop/public/locales/en/vault.json
@@ -341,11 +341,21 @@
           "placeholder": "Paste private key content"
         },
         "knownHosts": {
-          "label": "Known Hosts Data",
+          "label": "Known Hosts Entry",
           "placeholder": "Paste known_hosts content",
-          "warning": {
-            "title": "ECDSA format required",
-            "description": "The entry inside known_hosts currently must be in ecdsa-sha2-nistp256 format. You can run this command to retrieve it:"
+          "scan": {
+            "button": "Scan and fill",
+            "error": {
+              "KEYSCAN_NOT_INSTALLED": {
+                "title": "ssh-keyscan is not installed",
+                "description": "Please manually fill the known hosts field."
+              },
+              "SCAN_FAILED": {
+                "title": "Failed to scan with ssh-keyscan",
+                "description": "Please check your specified host and port."
+              }
+            },
+            "success": "Known hosts scanned successfully"
           }
         }
       }

--- a/apps/electron/src/ipc.ts
+++ b/apps/electron/src/ipc.ts
@@ -19,6 +19,7 @@ import {
   restoreSingle,
 } from "@electron/restore";
 import { openBrowser } from "@electron/shell";
+import { sshKeyscan } from "@electron/ssh";
 import { store } from "@electron/store";
 import { getVault, Vault } from "@electron/vault";
 import { window } from "@electron/window";
@@ -82,3 +83,5 @@ ipcMain.handle("shell.open.folder", (_, url) => shell.openPath(url));
 ipcMain.handle("shell.open.browser", (_, url) => openBrowser(url));
 
 ipcMain.handle("fs.folderSize", (_, path) => folderSize(path));
+
+ipcMain.handle("ssh.keyscan", (_, form) => sshKeyscan(form));

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -20,6 +20,7 @@ import {
   restoreMultiple,
   restoreSingle,
 } from "@electron/restore";
+import type { sshKeyscan } from "@electron/ssh";
 import type {
   AccountStorageSchema,
   GlobalStorageSchema,
@@ -196,6 +197,10 @@ const api = {
       off: (callback: (...args: any) => void) =>
         ipcRenderer.off("deeplink.open", callback),
     },
+  },
+  ssh: {
+    keyscan: (form: Parameters<typeof sshKeyscan>[0]) =>
+      ipcRenderer.invoke("ssh.keyscan", form) as ReturnType<typeof sshKeyscan>,
   },
 };
 

--- a/apps/electron/src/ssh.ts
+++ b/apps/electron/src/ssh.ts
@@ -1,0 +1,25 @@
+import type { ZSftpConfigType } from "@schemas/providers";
+import { execFile } from "child_process";
+
+export function sshKeyscan(form: ZSftpConfigType) {
+  return new Promise<{ error?: string; output?: string }>((res) => {
+    execFile("ssh-keyscan", (_1, _2, stderr) => {
+      if (!stderr.includes("usage:"))
+        return res({ error: "KEYSCAN_NOT_INSTALLED" });
+
+      execFile(
+        "ssh-keyscan",
+        ["-p", form.port.toString(), form.host],
+        {
+          timeout: 30_000,
+          maxBuffer: 200 * 1024,
+          env: { PATH: process.env.PATH ?? "" },
+        },
+        (err, stdout, stderr) => {
+          if (err || stderr) return res({ error: "SCAN_FAILED" });
+          res({ output: stdout });
+        },
+      );
+    });
+  });
+}

--- a/libs/schemas/src/providers.ts
+++ b/libs/schemas/src/providers.ts
@@ -73,7 +73,7 @@ export const ZSftpConfig = z.object({
   port: z.number().int().positive(),
   path: z.string().min(1).max(4096),
   password: z.string().max(128).optional(),
-  privateKey: z.string().min(1).max(10000),
+  privateKey: z.string().max(10000).optional(),
   knownHosts: z.string().min(1).max(10000),
 });
 


### PR DESCRIPTION
Implements #65 

- Set the private key field to optional, as the password auth method can be sufficient
- Implement a "Scan and fill" button for the known hosts, that runs ssh-keyscan automatically