### PR TITLE
fix(cloud): invalid download limit logic

### DIFF
--- a/apps/cloud/src/events/get.ts
+++ b/apps/cloud/src/events/get.ts
@@ -56,7 +56,7 @@ export async function getBlob(
     return { error: "DOWNLOAD_LIMIT_REACHED" };
   }
 
-  await storage.put("downloadedBytes", oldDownloadedBytes);
+  await storage.put("downloadedBytes", newDownloadedBytes);
 
   const url = await getSignedUrl(
     durableObject.s3,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the cloud download limit logic by persisting the updated downloadedBytes after serving a blob. Ensures downloads are tracked correctly and limits are enforced.

<sup>Written for commit 3bafb39b732b9a11250f3164b07fc604ad4cf61a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

