### PR TITLE
feat(desktop): add loading state to all setting views

### DIFF
--- a/apps/desktop/src/components/dialogs/create-folder/settings.tsx
+++ b/apps/desktop/src/components/dialogs/create-folder/settings.tsx
@@ -24,6 +24,7 @@ export function CreateFolderSettings({
 
   const [size, setSize] = useState<number | null>(null);
   const [alertShown, setAlertShown] = useState(false);
+  const [open, setOpen] = useState<string[]>([]);
 
   const { mutateAsync, isPending } = useCreateFolder({
     onError: (error) => {
@@ -37,12 +38,21 @@ export function CreateFolderSettings({
   return (
     <>
       <PolicyContextProvider level="FOLDER" mock={{ path: values.path }}>
-        <Accordion type="multiple" className="mt-2 w-full">
-          <ScheduleSettings />
-          <RetentionSettings />
-          <FilesSettings />
-        </Accordion>
-        <FolderSize path={values.path} setSize={setSize} />
+        {({ loading }) => (
+          <>
+            <Accordion
+              type="multiple"
+              className="mt-2 w-full"
+              value={loading ? [] : open}
+              onValueChange={setOpen}
+            >
+              <ScheduleSettings />
+              <RetentionSettings />
+              <FilesSettings />
+            </Accordion>
+            <FolderSize path={values.path} setSize={setSize} />
+          </>
+        )}
       </PolicyContextProvider>
       <Button
         onClick={() => mutateAsync({ ...values, size })}

--- a/apps/desktop/src/components/dialogs/folder-settings/index.tsx
+++ b/apps/desktop/src/components/dialogs/folder-settings/index.tsx
@@ -12,10 +12,13 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@ui/dialog";
+import { useState } from "react";
 
 export function FolderSettingsDialog() {
   const { t } = useAppTranslation("settings.folder");
   const { isOpen, setIsOpen, options } = useFolderSettingsDialog();
+
+  const [open, setOpen] = useState<string[]>([]);
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
@@ -26,12 +29,19 @@ export function FolderSettingsDialog() {
         </DialogDescription>
         <div className="mt-4">
           <PolicyContextProvider level="FOLDER" folderId={options?.folderId}>
-            <Accordion type="multiple" className="w-full">
-              <FolderGeneralSettings />
-              <ScheduleSettings />
-              <RetentionSettings />
-              <FilesSettings />
-            </Accordion>
+            {({ loading }) => (
+              <Accordion
+                type="multiple"
+                className="w-full"
+                value={loading ? [] : open}
+                onValueChange={setOpen}
+              >
+                <FolderGeneralSettings />
+                <ScheduleSettings />
+                <RetentionSettings />
+                <FilesSettings />
+              </Accordion>
+            )}
           </PolicyContextProvider>
         </div>
       </DialogContent>

--- a/apps/desktop/src/components/policy/category.tsx
+++ b/apps/desktop/src/components/policy/category.tsx
@@ -1,10 +1,12 @@
+import { PolicyContext } from "@desktop/components/policy/context";
 import { ZPolicyType } from "@schemas/policy";
 import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from "@ui/accordion";
-import { ReactNode } from "react";
+import { Skeleton } from "@ui/skeleton";
+import { ReactNode, useContext } from "react";
 
 type SettingsCategoryProps = {
   id: keyof ZPolicyType | string;
@@ -21,22 +23,31 @@ export function SettingsCategory({
   children,
   icon,
 }: SettingsCategoryProps) {
+  const { loading } = useContext(PolicyContext);
+
   return (
-    <AccordionItem value={id}>
-      <AccordionTrigger className="items-center">
+    <AccordionItem value={id} disabled={loading}>
+      <AccordionTrigger className="items-center" hideArrow={loading}>
         <div className="flex items-center gap-4">
-          <div className="bg-card text-muted-foreground flex size-11 items-center justify-center rounded-lg border-2 [&>svg]:size-5">
-            {icon}
-          </div>
+          {loading ? (
+            <Skeleton className="!size-11 !rounded-lg" />
+          ) : (
+            <div className="bg-card text-muted-foreground flex size-11 items-center justify-center rounded-lg border-2 [&>svg]:size-5">
+              {icon}
+            </div>
+          )}
           <div className="flex flex-col">
             <div className="flex items-center gap-1.5">
-              <h2 className="text-lg font-semibold">{title}</h2>
+              <h2 className="text-lg font-semibold">
+                {loading ? <Skeleton width={180} /> : title}
+              </h2>
             </div>
             <p className="text-muted-foreground text-xs font-normal">
-              {description}
+              {loading ? <Skeleton width={100} /> : description}
             </p>
           </div>
         </div>
+        {loading ? <Skeleton className="!size-4" /> : null}
       </AccordionTrigger>
       <AccordionContent className="m-1 pt-2">{children}</AccordionContent>
     </AccordionItem>

--- a/apps/desktop/src/components/policy/files.tsx
+++ b/apps/desktop/src/components/policy/files.tsx
@@ -213,7 +213,11 @@ type ExclusionRuleFilesEditorProps = {
   description: string;
 };
 
-function ExclusionRuleFilesEditor({ label, description, form }: ExclusionRuleFilesEditorProps) {
+function ExclusionRuleFilesEditor({
+  label,
+  description,
+  form,
+}: ExclusionRuleFilesEditorProps) {
   const { t } = useAppTranslation("policy.files");
 
   const field = useFieldContext<
@@ -246,7 +250,10 @@ function ExclusionRuleFilesEditor({ label, description, form }: ExclusionRuleFil
       {value && value.length > 0 ? (
         <div className="mb-2 mt-1 flex flex-col gap-3">
           {value.map((_, index) => (
-            <form.Field key={index} name={`exclusionRuleFiles[${index}].filename`}>
+            <form.Field
+              key={index}
+              name={`exclusionRuleFiles[${index}].filename`}
+            >
               {(subField) => (
                 <div className="flex w-full items-start justify-between gap-2">
                   <Input

--- a/apps/desktop/src/routes/app/{-$vaultId}/{-$hostName}/{-$userName}/settings.tsx
+++ b/apps/desktop/src/routes/app/{-$vaultId}/{-$hostName}/{-$userName}/settings.tsx
@@ -13,6 +13,7 @@ import { Accordion } from "@ui/accordion";
 import { Button } from "@ui/button";
 import { Skeleton } from "@ui/skeleton";
 import { HomeIcon } from "lucide-react";
+import { useState } from "react";
 
 export const Route = createFileRoute(
   "/app/{-$vaultId}/{-$hostName}/{-$userName}/settings",
@@ -23,6 +24,8 @@ export const Route = createFileRoute(
 function RouteComponent() {
   const { t } = useAppTranslation("settings.vault");
   const { data: vault } = useVault();
+
+  const [open, setOpen] = useState<string[]>([]);
 
   return (
     <div className="flex min-h-full flex-col overflow-x-hidden p-6">
@@ -56,14 +59,20 @@ function RouteComponent() {
       <div className="mt-auto"></div>
       <div className="lg:w-130 mx-auto w-full">
         <PolicyContextProvider level="VAULT">
-          <Accordion type="multiple">
-            <VaultGeneralSettings />
-            <VaultConfigSettings />
-            <ScheduleSettings />
-            <RetentionSettings />
-            <FilesSettings />
-            <VaultThrottleSettings />
-          </Accordion>
+          {({ loading }) => (
+            <Accordion
+              type="multiple"
+              value={loading ? [] : open}
+              onValueChange={setOpen}
+            >
+              <VaultGeneralSettings />
+              <VaultConfigSettings />
+              <ScheduleSettings />
+              <RetentionSettings />
+              <FilesSettings />
+              <VaultThrottleSettings />
+            </Accordion>
+          )}
         </PolicyContextProvider>
       </div>
       <div className="mb-auto"></div>

--- a/libs/ui/src/accordion.tsx
+++ b/libs/ui/src/accordion.tsx
@@ -25,8 +25,11 @@ function AccordionItem({
 function AccordionTrigger({
   className,
   children,
+  hideArrow = false,
   ...props
-}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger> & {
+  hideArrow?: boolean;
+}) {
   return (
     <AccordionPrimitive.Header className="flex">
       <AccordionPrimitive.Trigger
@@ -38,7 +41,9 @@ function AccordionTrigger({
         {...props}
       >
         {children}
-        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+        {!hideArrow ? (
+          <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+        ) : null}
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   );


### PR DESCRIPTION
Closes #10 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add loading states to all vault and folder settings views to prevent flicker and block interactions until policies are loaded. Shows skeleton placeholders and keeps accordions closed until data is ready.

- **New Features**
  - PolicyContext now exposes a loading flag from vault/folder queries.
  - Settings accordions stay closed and disabled while loading; category headers show skeletons and hide the chevron.
  - AccordionTrigger gains a hideArrow prop.

- **Refactors**
  - PolicyContextProvider now uses a render-prop child to access context.
  - Updated vault and folder settings and dialogs to manage accordion open state with useState.

<sup>Written for commit 3bc801e9137916bbf83f50715ef97d183a298174. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

