### PR TITLE
feat: show backup progress in dock

### DIFF
--- a/apps/desktop/src/hooks/use-taskbar-progress.ts
+++ b/apps/desktop/src/hooks/use-taskbar-progress.ts
@@ -1,0 +1,54 @@
+import { useFolderList } from "@desktop/hooks/queries/core/use-folder-list";
+import { useEffect, useRef } from "react";
+
+export function useTaskbarProgress() {
+  const { data: folders } = useFolderList();
+  const lastProgressRef = useRef<number>(-1);
+
+  useEffect(() => {
+    if (!folders) {
+      if (lastProgressRef.current !== -1) {
+        window.electron.window.setProgressBar(-1);
+        lastProgressRef.current = -1;
+      }
+      return;
+    }
+
+    const uploadingFolders = folders.filter(
+      (folder) => folder.status === "UPLOADING" && folder.upload,
+    );
+
+    if (uploadingFolders.length === 0) {
+      if (lastProgressRef.current !== -1) {
+        window.electron.window.setProgressBar(-1);
+        lastProgressRef.current = -1;
+      }
+      return;
+    }
+
+    let totalProcessed = 0;
+    let totalEstimated = 0;
+
+    for (const folder of uploadingFolders) {
+      if (folder.upload) {
+        totalProcessed += folder.upload.hashedBytes + folder.upload.cachedBytes;
+        totalEstimated += folder.upload.estimatedBytes;
+      }
+    }
+
+    const progress = totalEstimated > 0 ? totalProcessed / totalEstimated : 0;
+
+    const progressDelta = Math.abs(progress - lastProgressRef.current);
+    if (progressDelta > 0.005 || lastProgressRef.current === -1) {
+      const clampedProgress = Math.min(1, Math.max(0, progress));
+      window.electron.window.setProgressBar(clampedProgress);
+      lastProgressRef.current = clampedProgress;
+    }
+  }, [folders]);
+
+  useEffect(() => {
+    return () => {
+      window.electron.window.setProgressBar(-1);
+    };
+  }, []);
+}

--- a/apps/desktop/src/routes/app/{-$vaultId}/{-$hostName}/{-$userName}/route.tsx
+++ b/apps/desktop/src/routes/app/{-$vaultId}/{-$hostName}/{-$userName}/route.tsx
@@ -7,6 +7,7 @@ import { UpgradeDialog } from "@desktop/components/dialogs/upgrade";
 import { FolderDropzone } from "@desktop/components/folders/dropzone";
 import { useVaultPolicy } from "@desktop/hooks/queries/core/use-vault-policy";
 import { useSpaceUpdate } from "@desktop/hooks/use-space-update";
+import { useTaskbarProgress } from "@desktop/hooks/use-taskbar-progress";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute(
@@ -21,6 +22,7 @@ function RouteComponent() {
   // This will create the vault policy
   // in case it doesn't exist yet
   useVaultPolicy();
+  useTaskbarProgress();
 
   return (
     <>

--- a/apps/electron/src/ipc.ts
+++ b/apps/electron/src/ipc.ts
@@ -15,13 +15,14 @@ import { sshKeyscan } from "@electron/ssh";
 import { store } from "@electron/store";
 import { getUpdateStatus, installUpdate } from "@electron/updater";
 import { getVault, Vault } from "@electron/vault";
-import { window } from "@electron/window";
+import { setProgressBar, window } from "@electron/window";
 import { app, dialog, ipcMain, shell } from "electron";
 import { platform } from "node:os";
 import { basename, dirname, join } from "node:path";
 
 ipcMain.on("window.console", () => window?.webContents.toggleDevTools());
 ipcMain.on("window.reload", () => window?.reload());
+ipcMain.on("window.setProgressBar", (_, progress: number) => setProgressBar(progress));
 ipcMain.on("store.get", (e, key) => (e.returnValue = store.get(key)));
 ipcMain.on(
   "os.hostName",

--- a/apps/electron/src/preload.ts
+++ b/apps/electron/src/preload.ts
@@ -50,6 +50,8 @@ const api = {
   window: {
     reload: () => ipcRenderer.send("window.reload"),
     console: () => ipcRenderer.send("window.console"),
+    setProgressBar: (progress: number) =>
+      ipcRenderer.send("window.setProgressBar", progress),
   },
   store: {
     get: (

--- a/apps/electron/src/window.ts
+++ b/apps/electron/src/window.ts
@@ -60,3 +60,9 @@ export function sendWindow(channel: string, payload?: object) {
 
   window.webContents.send(channel, payload);
 }
+
+export function setProgressBar(progress: number) {
+  if (!window || window.isDestroyed()) return;
+
+  window.setProgressBar(progress);
+}


### PR DESCRIPTION
Closes #86 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows backup progress in the system dock/taskbar while folder backups are uploading, so users can track progress at a glance. Fulfills #86 and clears the indicator when uploads finish or when idle.

- New Features
  - Added useTaskbarProgress hook that aggregates processed vs estimated bytes across uploading folders.
  - Wired the hook into the app route to run during normal usage.
  - Added window.setProgressBar IPC in preload/ipc/window; updates only on >0.5% change, clamps to [0,1], and resets to -1 when no uploads or on unmount.

<sup>Written for commit 22871a80877e5b439c1d711d626fb53655e9c512. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

