### PR TITLE
feat: option to backup single files

### DIFF
--- a/apps/desktop/public/locales/en/backup.json
+++ b/apps/desktop/public/locales/en/backup.json
@@ -7,6 +7,7 @@
       "files_other": "{{formatted}} files",
       "dropdown": {
         "browse": "Browse files",
+        "download": "Download file",
         "delete": "Delete backup"
       }
     },

--- a/apps/desktop/public/locales/en/folder.json
+++ b/apps/desktop/public/locales/en/folder.json
@@ -1,21 +1,25 @@
 {
   "createDialog": {
-    "title": "Add folder",
-    "description": "Create a new folder to backup your files.",
+    "title": "Add file or folder",
+    "description": "Add a file or folder to backup.",
+    "type": {
+      "folder": "Folder",
+      "file": "File"
+    },
     "name": {
-      "label": "Folder name",
-      "placeholder": "Enter folder name"
+      "label": "Name",
+      "placeholder": "Enter name"
     },
     "emoji": {
       "button": "Change emoji"
     },
     "path": {
-      "label": "Folder path",
-      "placeholder": "Select folder path",
-      "title": "Select folder path"
+      "label": "Path",
+      "placeholder": "Select path",
+      "title": "Select path"
     },
     "continue": "Continue",
-    "submit": "Add folder",
+    "submit": "Add file or folder",
     "exceedingAlert": {
       "title": "Not enough cloud storage",
       "description": "This folder likely can’t be backed up because it would exceed your available BlinkDisk Cloud storage. To back it up, you’ll need to upgrade your BlinkDisk Cloud plan.",
@@ -45,8 +49,8 @@
     "empty": "No emoji found."
   },
   "dropzone": {
-    "title": "Drop folder to add",
-    "description": "Drop any files or folders to add it to your vault and start backing them up."
+    "title": "Drop to add",
+    "description": "Drop any files or folders to add them to your vault and start backing them up."
   },
   "list": {
     "item": {

--- a/apps/desktop/public/locales/en/sidebar.json
+++ b/apps/desktop/public/locales/en/sidebar.json
@@ -1,5 +1,5 @@
 {
-  "addFolder": "Add folder",
+  "addFolder": "Add file or folder",
   "selectHostName": {
     "empty": "Select device",
     "remote": "Remote"
@@ -28,6 +28,9 @@
   },
   "folderList": {
     "title": "Folders"
+  },
+  "fileList": {
+    "title": "Files"
   },
   "storageAlert": {
     "high": {

--- a/apps/desktop/public/locales/en/vault.json
+++ b/apps/desktop/public/locales/en/vault.json
@@ -350,11 +350,20 @@
       "title": "Folders",
       "count_one": "{{count}} folder backed up",
       "count_other": "{{count}} folders backed up",
-      "addFolder": "Add folder",
+      "addFolder": "Add file or folder",
       "backupAll": "Backup all",
       "empty": {
         "title": "No folders added",
-        "description": "You haven't added any folders yet. Add one by pressing the button below."
+        "description": "You haven't added any folders yet."
+      }
+    },
+    "files": {
+      "title": "Files",
+      "count_one": "{{count}} file backed up",
+      "count_other": "{{count}} files backed up",
+      "empty": {
+        "title": "No files added",
+        "description": "You haven't added any files yet."
       }
     },
     "score": {

--- a/apps/desktop/src/components/dialogs/create-folder/general.tsx
+++ b/apps/desktop/src/components/dialogs/create-folder/general.tsx
@@ -4,6 +4,8 @@ import { useAppTranslation } from "@hooks/use-app-translation";
 import { Button } from "@ui/button";
 import { EmojiCard } from "@ui/emoji-card";
 import { EmojiPicker } from "@ui/emoji-picker";
+import { Tabs, TabsList, TabsTrigger } from "@ui/tabs";
+import { FileIcon, FolderIcon } from "lucide-react";
 
 type CreateFolderGeneralProps = {
   form: ReturnType<typeof useCreateFolderForm>;
@@ -38,19 +40,47 @@ export function CreateFolderGeneral({ form }: CreateFolderGeneralProps) {
           <Button variant="outline">{t("emoji.button")}</Button>
         </EmojiPicker>
       </div>
+      <div className="flex flex-col gap-2">
+        <Tabs
+          value={values.type}
+          onValueChange={(value) => {
+            const newType = value as "file" | "folder";
+            form.setFieldValue("type", newType);
+
+            const currentEmoji = form.getFieldValue("emoji");
+            const isDefaultEmoji = currentEmoji === "📁" || currentEmoji === "📄";
+            if (isDefaultEmoji) {
+              form.setFieldValue("emoji", newType === "file" ? "📄" : "📁");
+            }
+          }}
+        >
+          <TabsList className="w-full">
+            <TabsTrigger value="folder" className="flex-1 gap-2">
+              <FolderIcon className="size-4" />
+              {t("type.folder")}
+            </TabsTrigger>
+            <TabsTrigger value="file" className="flex-1 gap-2">
+              <FileIcon className="size-4" />
+              {t("type.file")}
+            </TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </div>
       <form.AppField
         name="path"
         listeners={{
           onChange: async ({ value, fieldApi }) => {
-            if (!value || fieldApi.form.getFieldMeta("name")?.isDirty) return;
+            if (!value) return;
 
-            fieldApi.form.setFieldValue(
-              "name",
-              await window.electron.path.basename(value),
-              {
-                dontUpdateMeta: true,
-              },
-            );
+            if (!fieldApi.form.getFieldMeta("name")?.isDirty) {
+              fieldApi.form.setFieldValue(
+                "name",
+                await window.electron.path.basename(value),
+                {
+                  dontUpdateMeta: true,
+                },
+              );
+            }
           },
         }}
       >
@@ -59,7 +89,7 @@ export function CreateFolderGeneral({ form }: CreateFolderGeneralProps) {
             label={{ title: t("path.label"), required: true }}
             placeholder={t("path.placeholder")}
             title={t("path.title")}
-            type="directory"
+            type={values.type === "file" ? "file" : "directory"}
             className="ph-no-capture"
           />
         )}

--- a/apps/desktop/src/components/folders/dropzone.tsx
+++ b/apps/desktop/src/components/folders/dropzone.tsx
@@ -51,13 +51,13 @@ export function FolderDropzone() {
 
       const isDir = await window.electron.fs.isDirectory(firstPath);
 
-      const targetPath = isDir
-        ? firstPath
-        : await window.electron.path.dirname(firstPath);
+      const targetName = await window.electron.path.basename(firstPath);
 
-      const targetName = await window.electron.path.basename(targetPath);
-
-      openCreateFolder({ path: targetPath, name: targetName });
+      openCreateFolder({
+        path: firstPath,
+        name: targetName,
+        type: isDir ? "folder" : "file",
+      });
     },
     [openCreateFolder],
   );

--- a/apps/desktop/src/components/sidebar/add-folder.tsx
+++ b/apps/desktop/src/components/sidebar/add-folder.tsx
@@ -24,7 +24,7 @@ export function SidebarAddFolder() {
         <LocalButton
           className="bg-sidebar-muted border-sidebar-border w-full"
           variant="outline"
-          onClick={openCreateFolder}
+          onClick={() => openCreateFolder()}
         >
           <PlusIcon />
           <span>{t("addFolder")}</span>

--- a/apps/desktop/src/components/vaults/home.tsx
+++ b/apps/desktop/src/components/vaults/home.tsx
@@ -14,16 +14,18 @@ import { useAppTranslation } from "@hooks/use-app-translation";
 import { Button } from "@ui/button";
 import { Card, CardContent, CardTitle } from "@ui/card";
 import { CircularProgress } from "@ui/circular-progress";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@ui/collapsible";
 import { Skeleton } from "@ui/skeleton";
 import { cn } from "@utils/class";
 import {
+  ChevronDownIcon,
   CircleFadingArrowUpIcon,
   CloudUploadIcon,
   FolderPlusIcon,
   PlusIcon,
   SettingsIcon,
 } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { GaugeComponent } from "react-gauge-component";
 
 type VaultHomeProps = {
@@ -53,6 +55,17 @@ export function VaultHome({ vault, folders }: VaultHomeProps) {
       ),
     [folders],
   );
+
+  const { folderItems, fileItems } = useMemo(() => {
+    if (!folders) return { folderItems: undefined, fileItems: undefined };
+    return {
+      folderItems: folders.filter((f) => f.type !== "file"),
+      fileItems: folders.filter((f) => f.type === "file"),
+    };
+  }, [folders]);
+
+  const [foldersOpen, setFoldersOpen] = useState(true);
+  const [filesOpen, setFilesOpen] = useState(true);
 
   return (
     <>
@@ -223,7 +236,7 @@ export function VaultHome({ vault, folders }: VaultHomeProps) {
             </h2>
             <p className="text-muted-foreground text-xs">
               {folders !== undefined ? (
-                t("folders.count", { count: folders?.length })
+                t("folders.count", { count: folderItems?.length ?? 0 })
               ) : (
                 <Skeleton width={120} />
               )}
@@ -232,7 +245,7 @@ export function VaultHome({ vault, folders }: VaultHomeProps) {
           <div className="flex items-center gap-3">
             {folders !== undefined ? (
               <>
-                <LocalButton onClick={openCreateFolder} variant="outline">
+                <LocalButton onClick={() => openCreateFolder()} variant="outline">
                   <PlusIcon />
                   {t("folders.addFolder")}
                 </LocalButton>
@@ -260,13 +273,69 @@ export function VaultHome({ vault, folders }: VaultHomeProps) {
             title={t("folders.empty.title")}
             description={t("folders.empty.description")}
           >
-            <LocalButton onClick={openCreateFolder} size="lg">
+            <LocalButton onClick={() => openCreateFolder()} size="lg">
               <PlusIcon />
               {t("folders.addFolder")}
             </LocalButton>
           </Empty>
         ) : (
-          <FolderList folders={folders} />
+          <div className="flex flex-col gap-6">
+            <Collapsible open={foldersOpen} onOpenChange={setFoldersOpen}>
+              <CollapsibleTrigger className="flex w-full items-center gap-2 py-2">
+                <ChevronDownIcon
+                  className={cn(
+                    "text-muted-foreground size-4 transition-transform",
+                    !foldersOpen && "-rotate-90",
+                  )}
+                />
+                <span className="text-muted-foreground text-sm font-medium">
+                  {t("folders.title")}
+                </span>
+                <span className="text-muted-foreground text-xs">
+                  ({folderItems?.length ?? 0})
+                </span>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                {folderItems && folderItems.length > 0 ? (
+                  <FolderList folders={folderItems} />
+                ) : folderItems ? (
+                  <p className="text-muted-foreground py-4 text-center text-sm">
+                    {t("folders.empty.title")}
+                  </p>
+                ) : (
+                  <FolderList folders={undefined} />
+                )}
+              </CollapsibleContent>
+            </Collapsible>
+
+            <Collapsible open={filesOpen} onOpenChange={setFilesOpen}>
+              <CollapsibleTrigger className="flex w-full items-center gap-2 py-2">
+                <ChevronDownIcon
+                  className={cn(
+                    "text-muted-foreground size-4 transition-transform",
+                    !filesOpen && "-rotate-90",
+                  )}
+                />
+                <span className="text-muted-foreground text-sm font-medium">
+                  {t("files.title")}
+                </span>
+                <span className="text-muted-foreground text-xs">
+                  ({fileItems?.length ?? 0})
+                </span>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                {fileItems && fileItems.length > 0 ? (
+                  <FolderList folders={fileItems} />
+                ) : fileItems ? (
+                  <p className="text-muted-foreground py-4 text-center text-sm">
+                    {t("files.empty.title")}
+                  </p>
+                ) : (
+                  <FolderList folders={undefined} />
+                )}
+              </CollapsibleContent>
+            </Collapsible>
+          </div>
         )}
       </div>
     </>

--- a/apps/desktop/src/hooks/forms/use-create-folder-form.ts
+++ b/apps/desktop/src/hooks/forms/use-create-folder-form.ts
@@ -13,6 +13,7 @@ export function useCreateFolderForm({
       name: "",
       emoji: "📁",
       path: "",
+      type: "folder" as const,
       ...(defaultValues || {}),
     },
     validators: {

--- a/apps/desktop/src/hooks/mutations/core/use-create-folder.ts
+++ b/apps/desktop/src/hooks/mutations/core/use-create-folder.ts
@@ -71,6 +71,7 @@ export function useCreateFolder({
           ...(window.folderMockPolicy || {}),
           name: values.name,
           emoji: values.emoji,
+          type: values.type || "folder",
         },
       });
 

--- a/apps/desktop/src/hooks/queries/core/use-folder-list.ts
+++ b/apps/desktop/src/hooks/queries/core/use-folder-list.ts
@@ -13,6 +13,7 @@ export type CoreFolderItem = {
   id: string;
   name?: string;
   emoji?: string;
+  type?: "file" | "folder";
   source: {
     host: string;
     userName: string;
@@ -47,7 +48,7 @@ export type CoreFolderItem = {
     };
     rootEntry: {
       name: string;
-      type: string;
+      type: "d" | "f";
       mode: string;
       mtime: string;
       uid: number;
@@ -123,9 +124,17 @@ export function useFolderList() {
           path: folder.source.path,
         });
 
+        const derivedType: "file" | "folder" =
+          folder.lastSnapshot?.rootEntry?.type === "f"
+            ? "file"
+            : folder.type === "file"
+              ? "file"
+              : "folder";
+
         folders.push({
           ...folder,
           id,
+          type: derivedType,
         });
       }
 

--- a/libs/schemas/src/folder.ts
+++ b/libs/schemas/src/folder.ts
@@ -2,11 +2,14 @@ import { z } from "zod";
 
 export const ZFolderName = z.string().min(1).max(100);
 export const ZFolderEmoji = z.string().emoji().min(1);
+export const ZFolderType = z.enum(["file", "folder"]);
 
 export const ZCreateFolderForm = z.object({
   name: ZFolderName,
   emoji: ZFolderEmoji,
   path: z.string().min(1),
+  type: ZFolderType,
 });
 
 export type ZCreateFolderFormType = z.infer<typeof ZCreateFolderForm>;
+export type ZFolderTypeType = z.infer<typeof ZFolderType>;


### PR DESCRIPTION
Closes #88 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for backing up single files, alongside folders. Also lets you download file backups directly from the timeline.

- **New Features**
  - Create dialog now supports adding a file or a folder, with a file picker and type-aware default emoji.
  - Drag-and-drop accepts both files and folders and sets the correct type automatically.
  - Sidebar and Vault Home split items into “Files” and “Folders” with collapsible sections and counts.
  - File backups can be downloaded from the timeline card and dropdown (uses single-item restore).
  - Added “type” to schema, form, and create mutation; folder list derives type from the latest snapshot.
  - Updated English copy: “Add file or folder,” “Files,” and “Download file.”

<sup>Written for commit 66f078f7aef3c8bf2a0a392039e076c9f857451a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

