### PR TITLE
refactor(marketing): improve astro env variable loading

### DIFF
--- a/apps/marketing/astro.config.mjs
+++ b/apps/marketing/astro.config.mjs
@@ -1,15 +1,8 @@
-import { config } from "dotenv";
-
-config({
-  path: "../../.env",
-});
-
-import { defineConfig } from "astro/config";
+import { defineConfig, envField } from "astro/config";
 import cloudflare from "@astrojs/cloudflare";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
-import env from "vite-plugin-environment";
 import { fileURLToPath } from "url";
 import path from "path";
 
@@ -25,24 +18,19 @@ export default defineConfig({
         imageService: "compile",
     }),
     integrations: [react(), sitemap()],
+    env: {
+        schema: {
+            API_URL: envField.string({ context: "server", access: "public", optional: true }),
+            MARKETING_URL: envField.string({ context: "server", access: "public", optional: true }),
+            LOGSNAG_PUBLIC_KEY: envField.string({ context: "client", access: "public", optional: true }),
+            POSTHOG_MARKETING_KEY: envField.string({ context: "server", access: "public", optional: true }),
+            POSTHOG_API_HOST: envField.string({ context: "server", access: "public", optional: true }),
+            ENDORSELY_PUBLIC_KEY: envField.string({ context: "server", access: "public", optional: true }),
+            CRISP_KEY: envField.string({ context: "server", access: "public", optional: true }),
+        },
+    },
     vite: {
-        plugins: [
-          tailwindcss(),
-          env(
-            {
-              API_URL: null,
-              MARKETING_URL: null,
-              LOGSNAG_PUBLIC_KEY: null,
-              POSTHOG_MARKETING_KEY: null,
-              POSTHOG_API_HOST: null,
-              ENDORSELY_PUBLIC_KEY: null,
-              CRISP_KEY: null,
-            },
-            {
-              loadEnvFiles: false,
-            },
-          )
-        ],
+        plugins: [tailwindcss()],
         resolve: {
             alias: {
                 "@marketing": path.resolve(__dirname, "./src"),

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "astro dev",
+    "dev": "cp ../../.env .env && astro dev",
     "build": "astro build",
     "preview": "astro preview",
     "typecheck": "astro check",
@@ -47,10 +47,8 @@
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",
     "@types/twemoji-parser": "^13.1.4",
-    "dotenv": "^16.4.7",
     "eslint-plugin-astro": "^1.5.0",
     "typescript": "5.8.2",
-    "vite-plugin-environment": "^1.1.3",
     "wrangler": "^4.62.0"
   }
 }

--- a/apps/marketing/src/hooks/use-logsnag.ts
+++ b/apps/marketing/src/hooks/use-logsnag.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { LOGSNAG_PUBLIC_KEY } from "astro:env/client";
 
 type LogsnagOptions = {
   channel: string;
@@ -20,7 +21,7 @@ export function useLogsnag() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${import.meta.env.LOGSNAG_KEY}`,
+          Authorization: `Bearer ${LOGSNAG_PUBLIC_KEY}`,
         },
         body: JSON.stringify({
           project: "blinkdisk",

--- a/apps/marketing/src/layouts/BaseLayout.astro
+++ b/apps/marketing/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
 import "@marketing/styles.css";
 import ThemeScript from "@marketing/components/ThemeScript.astro";
+import { MARKETING_URL, POSTHOG_MARKETING_KEY, POSTHOG_API_HOST, ENDORSELY_PUBLIC_KEY, CRISP_KEY } from "astro:env/server";
 
 import inter400 from "@fontsource/inter/files/inter-latin-400-normal.woff2";
 import inter500 from "@fontsource/inter/files/inter-latin-500-normal.woff2";
@@ -21,8 +22,8 @@ export type Props = {
 const defaultTitle = "BlinkDisk | Backup and secure your files";
 const defaultDescription =
   "BlinkDisk is a desktop application that lets you effortlessly backup all your important files with just a few clicks.";
-const defaultImage = `${import.meta.env.MARKETING_URL || "https://blinkdisk.com"}/brand/social.jpg`;
-const siteUrl = import.meta.env.MARKETING_URL || "https://blinkdisk.com";
+const defaultImage = `${MARKETING_URL ?? "https://blinkdisk.com"}/brand/social.jpg`;
+const siteUrl = MARKETING_URL ?? "https://blinkdisk.com";
 
 const { title, description, image, og, structuredData } = Astro.props;
 
@@ -33,10 +34,10 @@ const pageImage = image || defaultImage;
 const ogTitle = og?.title || pageTitle;
 const ogImage = og?.image ? `${siteUrl}${og.image}` : pageImage;
 
-const posthogKey = import.meta.env.POSTHOG_MARKETING_KEY || "";
-const posthogHost = import.meta.env.POSTHOG_API_HOST || "";
-const endorselyKey = import.meta.env.ENDORSELY_PUBLIC_KEY || "";
-const crispKey = import.meta.env.CRISP_KEY || "";
+const posthogKey = POSTHOG_MARKETING_KEY ?? "";
+const posthogHost = POSTHOG_API_HOST ?? "";
+const endorselyKey = ENDORSELY_PUBLIC_KEY ?? "";
+const crispKey = CRISP_KEY ?? "";
 
 const organizationSchema = {
   "@context": "https://schema.org",

--- a/apps/marketing/src/pages/checkout/redirect.astro
+++ b/apps/marketing/src/pages/checkout/redirect.astro
@@ -1,7 +1,8 @@
 ---
 import BaseLayout from "@marketing/layouts/BaseLayout.astro";
+import { API_URL } from "astro:env/server";
 
-const apiUrl = import.meta.env.API_URL || "https://api.blinkdisk.com";
+const apiUrl = API_URL ?? "https://api.blinkdisk.com";
 ---
 
 <BaseLayout title="Redirecting...">

--- a/apps/marketing/src/pages/download.astro
+++ b/apps/marketing/src/pages/download.astro
@@ -1,8 +1,9 @@
 ---
 import DefaultLayout from "@marketing/layouts/DefaultLayout.astro";
 import DownloadClient from "@marketing/components/react/DownloadClient";
+import { API_URL } from "astro:env/server";
 
-const apiUrl = import.meta.env.API_URL;
+const apiUrl = API_URL ?? "https://api.blinkdisk.com";
 ---
 
 <DefaultLayout

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -8,8 +8,9 @@ import Features from "@marketing/sections/Features.astro";
 import Downloads from "@marketing/sections/Downloads.astro";
 import Faq from "@marketing/sections/Faq.astro";
 import { getFaqStructuredData } from "@marketing/data/faqs";
+import { MARKETING_URL } from "astro:env/server";
 
-const siteUrl = import.meta.env.MARKETING_URL || "https://blinkdisk.com";
+const siteUrl = MARKETING_URL ?? "https://blinkdisk.com";
 
 const softwareSchema = {
   "@context": "https://schema.org",

--- a/apps/marketing/src/pages/pricing.astro
+++ b/apps/marketing/src/pages/pricing.astro
@@ -4,8 +4,9 @@ import PlanSelector from "@marketing/components/react/PlanSelector";
 import { plans } from "@config/plans";
 import { FREE_SPACE_AVAILABLE } from "@config/space";
 import { CheckIcon } from "lucide-react";
+import { MARKETING_URL } from "astro:env/server";
 
-const siteUrl = import.meta.env.MARKETING_URL || "https://blinkdisk.com";
+const siteUrl = MARKETING_URL ?? "https://blinkdisk.com";
 const freeStorageGB = Math.round(FREE_SPACE_AVAILABLE / 1000 / 1000 / 1000);
 
 const planOffers = plans

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -454,18 +454,12 @@ importers:
       '@types/twemoji-parser':
         specifier: ^13.1.4
         version: 13.1.4
-      dotenv:
-        specifier: ^16.4.7
-        version: 16.4.7
       eslint-plugin-astro:
         specifier: ^1.5.0
         version: 1.5.0(eslint@9.22.0)
       typescript:
         specifier: 5.8.2
         version: 5.8.2
-      vite-plugin-environment:
-        specifier: ^1.1.3
-        version: 1.1.3(vite@6.4.1)
       wrangler:
         specifier: ^4.62.0
         version: 4.62.0
@@ -5615,6 +5609,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-android-arm64@4.36.0:
@@ -5629,6 +5624,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.36.0:
@@ -5643,6 +5639,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-darwin-x64@4.36.0:
@@ -5657,6 +5654,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-freebsd-arm64@4.36.0:
@@ -5671,6 +5669,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-freebsd-x64@4.36.0:
@@ -5685,6 +5684,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.36.0:
@@ -5699,6 +5699,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-arm-musleabihf@4.36.0:
@@ -5713,6 +5714,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-arm64-gnu@4.36.0:
@@ -5727,6 +5729,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.36.0:
@@ -5741,6 +5744,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-loong64-gnu@4.52.4:
@@ -5748,6 +5752,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-loongarch64-gnu@4.36.0:
@@ -5769,6 +5774,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-riscv64-gnu@4.36.0:
@@ -5783,6 +5789,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-riscv64-musl@4.52.4:
@@ -5790,6 +5797,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-s390x-gnu@4.36.0:
@@ -5804,6 +5812,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.36.0:
@@ -5818,6 +5827,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-x64-musl@4.36.0:
@@ -5832,6 +5842,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-openharmony-arm64@4.52.4:
@@ -5839,6 +5850,7 @@ packages:
     cpu: [arm64]
     os: [openharmony]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-win32-arm64-msvc@4.36.0:
@@ -5853,6 +5865,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-win32-ia32-msvc@4.36.0:
@@ -5867,6 +5880,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-win32-x64-gnu@4.52.4:
@@ -5874,6 +5888,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-win32-x64-msvc@4.36.0:
@@ -5888,6 +5903,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@selderee/plugin-htmlparser2@0.11.0:
@@ -7978,6 +7994,7 @@ packages:
 
   /@types/estree@1.0.8:
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+    dev: false
 
   /@types/fs-extra@9.0.13:
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
@@ -11176,6 +11193,7 @@ packages:
         optional: true
     dependencies:
       picomatch: 4.0.3
+    dev: false
 
   /fflate@0.4.8:
     resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
@@ -15541,6 +15559,7 @@ packages:
       '@rollup/rollup-win32-x64-gnu': 4.52.4
       '@rollup/rollup-win32-x64-msvc': 4.52.4
       fsevents: 2.3.3
+    dev: false
 
   /rou3@0.5.1:
     resolution: {integrity: sha512-OXMmJ3zRk2xeXFGfA3K+EOPHC5u7RDFG7lIOx0X1pdnhUkI8MdVrbV+sNsD80ElpUZ+MRHdyxPnFthq9VHs8uQ==}
@@ -16482,6 +16501,7 @@ packages:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+    dev: false
 
   /tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -17240,14 +17260,6 @@ packages:
       vite: 6.2.2(@types/node@22.13.10)
     dev: true
 
-  /vite-plugin-environment@1.1.3(vite@6.4.1):
-    resolution: {integrity: sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==}
-    peerDependencies:
-      vite: '>= 2.7'
-    dependencies:
-      vite: 6.4.1(@types/node@22.13.10)
-    dev: true
-
   /vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.2.2):
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
@@ -17361,6 +17373,7 @@ packages:
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
+    dev: false
 
   /vitefu@1.1.1(vite@6.4.1):
     resolution: {integrity: sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ==}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch the marketing app to Astro’s built‑in env API with a typed schema and safe server/client imports. Removes custom env tooling and adds sensible fallbacks to prevent missing-var issues.

- **Refactors**
  - Define a typed env schema in astro.config.mjs and drop the custom Vite env plugin; dev now copies the root .env before start.
  - Replace import.meta.env with astro:env/server or astro:env/client across the app; Logsnag now uses LOGSNAG_PUBLIC_KEY.
  - Add defaults for API_URL and MARKETING_URL to production URLs when unset.

- **Dependencies**
  - Remove dotenv and vite-plugin-environment.

<sup>Written for commit b82c5c911088c5459a22f95f365f2e065c760c7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

