### PR TITLE
fix(desktop): infinite loading when adding config

### DIFF
--- a/apps/desktop/src/components/vaults/config-missing.tsx
+++ b/apps/desktop/src/components/vaults/config-missing.tsx
@@ -40,7 +40,9 @@ export function ConfigMissing({ vault }: ConfigMissingProps) {
                 vault &&
                 addVaultConfig({
                   config,
-                  vaultId: vault?.id,
+                  vaultId: vault.id,
+                  name: vault.name,
+                  provider: vault.provider,
                 })
               }
             />

--- a/apps/desktop/src/hooks/mutations/use-create-vault.ts
+++ b/apps/desktop/src/hooks/mutations/use-create-vault.ts
@@ -105,7 +105,7 @@ export function useCreateVault(onSuccess: (res: CreateVaultResponse) => void) {
           }),
         );
 
-        if (error || res.error) {
+        if (error || (res.error && res.error !== "ALREADY_CONNECTED")) {
           // Clean up vault if it was created
           if (created) await tryCatch(trpc.vault.delete.mutate({ vaultId }));
 

--- a/apps/electron/src/vault.ts
+++ b/apps/electron/src/vault.ts
@@ -443,7 +443,7 @@ export class Vault {
     await vault.boot();
 
     try {
-      const response = (await vault.fetch({
+      const response = await vault.fetch({
         method: "POST",
         path: "/api/v1/repo/connect",
         data: {
@@ -458,10 +458,10 @@ export class Vault {
           },
           password,
         },
-      })) as { error?: string };
+      });
 
       vault.stop();
-      return response as { error?: string };
+      return response as { error?: string; code?: string };
     } catch (e) {
       vault.stop();
       return e as { code?: string; error?: string };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes infinite loading when adding a vault config by connecting the vault first and gracefully handling “ALREADY_CONNECTED” responses. Users can now add configs without getting stuck on the spinner.

- **Bug Fixes**
  - Connect vault in useAddVaultConfig before calling config.add; accept ALREADY_CONNECTED.
  - Pass vault name and provider to addVaultConfig from ConfigMissing.
  - Electron vault.connect now returns error and code; improved response handling.
  - Ignore ALREADY_CONNECTED in useCreateVault to prevent unnecessary cleanup.

<sup>Written for commit 927701df3ccd8183fd239c5dbcbf061bb8637064. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

