### PR TITLE
feat(desktop): implement backup renaming

### DIFF
--- a/apps/desktop/public/locales/en/backup.json
+++ b/apps/desktop/public/locales/en/backup.json
@@ -7,6 +7,7 @@
       "files_other": "{{formatted}} files",
       "dropdown": {
         "browse": "Browse files",
+        "rename": "Rename backup",
         "delete": "Delete backup"
       }
     },
@@ -56,6 +57,13 @@
         "fallback": "{{completed}} processed"
       }
     }
+  },
+  "renameDialog": {
+    "title": "Rename backup",
+    "description": "Give this backup a custom name to find it more easily.",
+    "label": "Name",
+    "placeholder": "My backup",
+    "continue": "Rename backup"
   },
   "deleteDialog": {
     "title": "Delete backup",

--- a/apps/desktop/src/components/dialogs/rename-backup/index.tsx
+++ b/apps/desktop/src/components/dialogs/rename-backup/index.tsx
@@ -1,0 +1,61 @@
+import { useRenameBackupForm } from "@desktop/hooks/forms/use-rename-backup-form";
+import { useRenameBackupDialog } from "@desktop/hooks/state/use-rename-backup-dialog";
+import { useAppTranslation } from "@hooks/use-app-translation";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@ui/dialog";
+
+export function RenameBackupDialog() {
+  const { t } = useAppTranslation("backup.renameDialog");
+
+  const { isOpen, setIsOpen, options } = useRenameBackupDialog();
+
+  const form = useRenameBackupForm({
+    backupId: options?.backupId,
+    currentName: options?.currentName ?? "",
+    onSuccess: () => setIsOpen(false),
+  });
+
+  return (
+    <Dialog
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      onClosed={() => form.reset()}
+    >
+      <DialogContent className="w-90">
+        <DialogHeader>
+          <DialogTitle>{t("title")}</DialogTitle>
+          <DialogDescription className="sr-only">
+            {t("description")}
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            form.handleSubmit(e);
+          }}
+          className="mt-4 flex w-full flex-col gap-4"
+        >
+          <form.AppField name="name">
+            {(field) => (
+              <field.Text
+                label={{ title: t("label") }}
+                placeholder={t("placeholder")}
+              />
+            )}
+          </form.AppField>
+          <DialogFooter>
+            <form.AppForm>
+              <form.Submit>{t("continue")}</form.Submit>
+            </form.AppForm>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/desktop/src/hooks/forms/use-rename-backup-form.ts
+++ b/apps/desktop/src/hooks/forms/use-rename-backup-form.ts
@@ -1,0 +1,37 @@
+import { useEditBackup } from "@desktop/hooks/mutations/core/use-edit-backup";
+import { useAppForm } from "@hooks/use-app-form";
+import { z } from "zod";
+
+const ZRenameBackup = z.object({
+  name: z.string(),
+});
+
+export function useRenameBackupForm({
+  backupId,
+  currentName,
+  onSuccess,
+}: {
+  backupId: string | undefined;
+  currentName: string;
+  onSuccess?: () => void;
+}) {
+  const { mutateAsync } = useEditBackup({ onSuccess });
+
+  const form = useAppForm({
+    defaultValues: {
+      name: currentName,
+    },
+    validators: {
+      onSubmit: ZRenameBackup,
+    },
+    onSubmit: async ({ value }) => {
+      if (!backupId) return;
+      await mutateAsync({
+        backupId,
+        description: value.name,
+      });
+    },
+  });
+
+  return form;
+}

--- a/apps/desktop/src/hooks/mutations/core/use-edit-backup.ts
+++ b/apps/desktop/src/hooks/mutations/core/use-edit-backup.ts
@@ -1,0 +1,41 @@
+import { useFolder } from "@desktop/hooks/use-folder";
+import { useQueryKey } from "@desktop/hooks/use-query-key";
+import { useVaultId } from "@desktop/hooks/use-vault-id";
+import { showErrorToast } from "@desktop/lib/error";
+import { vaultApi } from "@desktop/lib/vault";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { CustomError } from "@utils/error";
+
+export function useEditBackup({ onSuccess }: { onSuccess?: () => void }) {
+  const queryClient = useQueryClient();
+
+  const { data: folder } = useFolder();
+  const { queryKeys } = useQueryKey();
+  const { vaultId } = useVaultId();
+
+  return useMutation({
+    mutationKey: ["core", "backup", "edit"],
+    mutationFn: async ({
+      backupId,
+      description,
+    }: {
+      backupId: string;
+      description: string;
+    }) => {
+      if (!vaultId) throw new CustomError("MISSING_REQUIRED_VALUE");
+
+      await vaultApi(vaultId).post("/api/v1/snapshots/edit", {
+        snapshots: [backupId],
+        description,
+      });
+    },
+    onError: showErrorToast,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.backup.list(folder?.id),
+      });
+
+      onSuccess?.();
+    },
+  });
+}

--- a/apps/desktop/src/hooks/state/use-rename-backup-dialog.ts
+++ b/apps/desktop/src/hooks/state/use-rename-backup-dialog.ts
@@ -1,0 +1,40 @@
+import { Store, useStore } from "@tanstack/react-store";
+import { useCallback } from "react";
+
+type RenameBackupDialogOptions = {
+  backupId: string;
+  currentName: string;
+};
+
+const store = new Store<{
+  isOpen: boolean;
+  options: RenameBackupDialogOptions | null;
+}>({
+  isOpen: false,
+  options: null,
+});
+
+export function useRenameBackupDialog() {
+  const { isOpen, options } = useStore(store);
+
+  const setIsOpen = useCallback((to: boolean) => {
+    store.setState((state) => ({
+      ...state,
+      isOpen: to,
+    }));
+  }, []);
+
+  function openRenameBackupDialog(options: RenameBackupDialogOptions) {
+    store.setState({
+      isOpen: true,
+      options,
+    });
+  }
+
+  return {
+    isOpen,
+    setIsOpen,
+    openRenameBackupDialog,
+    options,
+  };
+}

--- a/apps/desktop/src/lib/backup.ts
+++ b/apps/desktop/src/lib/backup.ts
@@ -1,0 +1,14 @@
+export function getBackupDisplayName(backup: {
+  description: string;
+  startTime: string;
+}): string {
+  if (backup.description) return backup.description;
+  return formatBackupDate(backup);
+}
+
+export function formatBackupDate(backup: { startTime: string }): string {
+  return new Date(backup.startTime).toLocaleString(undefined, {
+    timeStyle: "short",
+    dateStyle: "short",
+  });
+}

--- a/apps/desktop/src/routes/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/route.tsx
+++ b/apps/desktop/src/routes/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/route.tsx
@@ -1,4 +1,5 @@
 import { DeleteBackupDialog } from "@desktop/components/dialogs/delete-backup";
+import { RenameBackupDialog } from "@desktop/components/dialogs/rename-backup";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute(
@@ -11,6 +12,7 @@ function RouteComponent() {
   return (
     <>
       <DeleteBackupDialog />
+      <RenameBackupDialog />
       <Outlet />
     </>
   );

--- a/apps/desktop/src/routes/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/index.tsx
+++ b/apps/desktop/src/routes/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/index.tsx
@@ -6,6 +6,7 @@ import { useDirectory } from "@desktop/hooks/queries/core/use-directory";
 import { useVault } from "@desktop/hooks/queries/use-vault";
 import { useBackup } from "@desktop/hooks/use-backup";
 import { useFolder } from "@desktop/hooks/use-folder";
+import { getBackupDisplayName } from "@desktop/lib/backup";
 import { useAppTranslation } from "@hooks/use-app-translation";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { Button } from "@ui/button";
@@ -58,11 +59,7 @@ function RouteComponent() {
                 },
                 {
                   id: "backup",
-                  text:
-                    new Date(backup.startTime).toLocaleString(undefined, {
-                      timeStyle: "short",
-                      dateStyle: "short",
-                    }) || "",
+                  text: getBackupDisplayName(backup),
                   href:
                     !path || !path.length
                       ? undefined


### PR DESCRIPTION
Part of #143

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds backup renaming to the desktop app. Users can name backups from the timeline menu, and the name shows in the list and breadcrumb. Part of #143.

- **New Features**
  - Added “Rename backup” action in the timeline menu with a RenameBackupDialog.
  - Persist name via use-edit-backup (POST /api/v1/snapshots/edit) and invalidate backup list on success.
  - Updated UI to show custom name next to relative time and use a formatted calendar date; breadcrumbs use getBackupDisplayName.
  - Added i18n strings for the rename flow and wired the dialog into the app route and state store.

<sup>Written for commit 97d9493ef05491b1373cb1c76e8c2c15511509a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

