### PR TITLE
refactor(desktop): track accountId state in url

### DIFF
--- a/apps/desktop/src/components/auth-listener.tsx
+++ b/apps/desktop/src/components/auth-listener.tsx
@@ -11,7 +11,7 @@ export function AuthListener() {
     await navigate({ to: "/{-$accountId}/loading" });
 
     const session = await accountChanged();
-    if (!session) return;
+    if (!session) return navigate({ to: "/" });
 
     navigate({ to: "/{-$accountId}", params: { accountId: session.user.id } });
   }, [setAuthenticated, accountChanged, navigate]);

--- a/apps/desktop/src/components/auth-listener.tsx
+++ b/apps/desktop/src/components/auth-listener.tsx
@@ -8,9 +8,12 @@ export function AuthListener() {
 
   const onAccountChange = useCallback(async () => {
     await setAuthenticated(true);
-    await navigate({ to: "/app/loading" });
-    await accountChanged();
-    navigate({ to: "/app" });
+    await navigate({ to: "/{-$accountId}/loading" });
+
+    const session = await accountChanged();
+    if (!session) return;
+
+    navigate({ to: "/{-$accountId}", params: { accountId: session.user.id } });
   }, [setAuthenticated, accountChanged, navigate]);
 
   useEffect(() => {

--- a/apps/desktop/src/components/backups/timeline.tsx
+++ b/apps/desktop/src/components/backups/timeline.tsx
@@ -262,7 +262,7 @@ export function Backup({ backup }: BackupProps) {
   return (
     <div role="link" className={cn(cardClassName, "hover:bg-card-hover")}>
       <Link
-        to="/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}"
+        to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}"
         params={(params) => ({
           ...params,
           backupId: backup?.id || "",
@@ -343,7 +343,7 @@ export function Backup({ backup }: BackupProps) {
               <DropdownMenuItem
                 render={
                   <Link
-                    to="/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}"
+                    to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}"
                     params={(params) => ({
                       ...params,
                       backupId: backup?.id || "",

--- a/apps/desktop/src/components/dialogs/create-vault/details.tsx
+++ b/apps/desktop/src/components/dialogs/create-vault/details.tsx
@@ -30,7 +30,7 @@ export function CreateVaultDetails({
     providerType,
     onSuccess: async (res) => {
       await navigate({
-        to: "/app/{-$vaultId}/{-$hostName}/{-$userName}",
+        to: "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}",
         params: {
           vaultId: res.vaultId,
           hostName: window.electron.os.hostName(res.vaultId),

--- a/apps/desktop/src/components/dialogs/delete-vault/index.tsx
+++ b/apps/desktop/src/components/dialogs/delete-vault/index.tsx
@@ -1,3 +1,4 @@
+import { DynamicField } from "@blinkdisk/components/dynamic-field";
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
 import { Alert, AlertDescription, AlertTitle } from "@blinkdisk/ui/alert";
 import { Button } from "@blinkdisk/ui/button";
@@ -9,7 +10,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@blinkdisk/ui/dialog";
-import { DynamicField } from "@blinkdisk/components/dynamic-field";
 import { Input } from "@blinkdisk/ui/input";
 import { useDeleteVault } from "@desktop/hooks/mutations/use-delete-vault";
 import { useVault } from "@desktop/hooks/queries/use-vault";
@@ -44,7 +44,7 @@ export function DeleteVaultDialog() {
     setIsOpen(false);
 
     await navigate({
-      to: "/app",
+      to: "/{-$accountId}",
     });
   }, [navigate, setIsOpen]);
 

--- a/apps/desktop/src/components/directories/row.tsx
+++ b/apps/desktop/src/components/directories/row.tsx
@@ -30,7 +30,7 @@ export function DirectoryItemRow({
           reset();
 
           navigate({
-            to: "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
+            to: "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
             params: (params) => ({
               ...params,
               directoryId: row.original.objectId || "",

--- a/apps/desktop/src/components/folders/list.tsx
+++ b/apps/desktop/src/components/folders/list.tsx
@@ -78,7 +78,7 @@ function Folder({ folder }: FolderProps) {
       className="bg-card hover:bg-card-hover ring-ring relative flex flex-row items-center justify-between gap-2 rounded-2xl border p-4 outline-none transition-colors focus-visible:ring-2"
     >
       <Link
-        to="/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}"
+        to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}"
         params={(params) => ({
           ...params,
           folderId: folder?.id || "",
@@ -116,7 +116,7 @@ function Folder({ folder }: FolderProps) {
               <DropdownMenuItem
                 render={
                   <Link
-                    to="/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}"
+                    to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}"
                     params={(params) => ({
                       ...params,
                       folderId: folder?.id || "",

--- a/apps/desktop/src/components/sidebar/folder-list.tsx
+++ b/apps/desktop/src/components/sidebar/folder-list.tsx
@@ -53,7 +53,7 @@ function SidebarFolder({ folder }: SidebarFolderProps) {
         isActive={folder && folderId === folder?.id}
         render={
           <Link
-            to="/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}"
+            to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}"
             params={(params) => ({
               ...params,
               folderId: folder?.id || "",

--- a/apps/desktop/src/components/sidebar/index.tsx
+++ b/apps/desktop/src/components/sidebar/index.tsx
@@ -27,7 +27,9 @@ export function Sidebar({ ...props }: ComponentProps<typeof SidebarContainer>) {
   const { data: session } = useAccount();
   const { data: folders } = useFolderList();
 
-  const { vaultId, hostName, userName } = useParams({ strict: false });
+  const { accountId, vaultId, hostName, userName } = useParams({
+    strict: false,
+  });
 
   const { t } = useAppTranslation("sidebar.links");
 
@@ -41,7 +43,7 @@ export function Sidebar({ ...props }: ComponentProps<typeof SidebarContainer>) {
         <SidebarHeader>
           <SidebarMenu>
             <SidebarMenuItem className="pl-2 pt-1">
-              <Link to="/app" tabIndex={-1}>
+              <Link to="/{-$accountId}" tabIndex={-1}>
                 <Logo />
               </Link>
             </SidebarMenuItem>
@@ -55,10 +57,11 @@ export function Sidebar({ ...props }: ComponentProps<typeof SidebarContainer>) {
                 <SidebarMenuButton
                   className="px-3"
                   isActive={
-                    pathname === `/app/${vaultId}/${hostName}/${userName}`
+                    pathname ===
+                    `/${accountId}/${vaultId}/${hostName}/${userName}`
                   }
                   render={
-                    <Link to="/app/{-$vaultId}/{-$hostName}/{-$userName}">
+                    <Link to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}">
                       <HomeIcon />
                       {t("home")}
                     </Link>
@@ -70,10 +73,10 @@ export function Sidebar({ ...props }: ComponentProps<typeof SidebarContainer>) {
                   className="px-3"
                   isActive={
                     pathname ===
-                    `/app/${vaultId}/${hostName}/${userName}/settings`
+                    `/${accountId}/${vaultId}/${hostName}/${userName}/settings`
                   }
                   render={
-                    <Link to="/app/{-$vaultId}/{-$hostName}/{-$userName}/settings">
+                    <Link to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings">
                       <SettingsIcon />
                       {t("settings")}
                     </Link>

--- a/apps/desktop/src/components/vaults/breadcrumb.tsx
+++ b/apps/desktop/src/components/vaults/breadcrumb.tsx
@@ -35,7 +35,7 @@ export function VaultBreadcrumb({ vault, breadcrumbs }: VaultBreadcrumbProps) {
             className="text-base"
             render={
               vault ? (
-                <Link to="/app/{-$vaultId}/{-$hostName}/{-$userName}">
+                <Link to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}">
                   {vault.name}
                 </Link>
               ) : (

--- a/apps/desktop/src/components/vaults/home.tsx
+++ b/apps/desktop/src/components/vaults/home.tsx
@@ -90,7 +90,7 @@ export function VaultHome({ vault, folders }: VaultHomeProps) {
             ) : (
               <Button
                 render={
-                  <Link to="/app/{-$vaultId}/{-$hostName}/{-$userName}/settings" />
+                  <Link to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings" />
                 }
                 nativeButton={false}
                 variant="outline"

--- a/apps/desktop/src/hooks/mutations/core/use-create-folder.ts
+++ b/apps/desktop/src/hooks/mutations/core/use-create-folder.ts
@@ -101,7 +101,7 @@ export function useCreateFolder({
       ]);
 
       await navigate({
-        to: "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
+        to: "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
         params: (params) => ({
           ...params,
           folderId: res.id,

--- a/apps/desktop/src/hooks/use-account-id.ts
+++ b/apps/desktop/src/hooks/use-account-id.ts
@@ -1,6 +1,6 @@
-import { useAppStorage } from "@desktop/hooks/use-app-storage";
+import { useParams } from "@tanstack/react-router";
 
 export function useAccountId() {
-  const [accountId, setAccountId] = useAppStorage("currentAccountId");
-  return { accountId, setAccountId };
+  const { accountId } = useParams({ strict: false });
+  return { accountId };
 }

--- a/apps/desktop/src/hooks/use-auth.ts
+++ b/apps/desktop/src/hooks/use-auth.ts
@@ -1,7 +1,6 @@
 import type { getSession } from "@blinkdisk/electron/auth";
 import { useAccount } from "@desktop/hooks/queries/use-account";
 import { useAccountList } from "@desktop/hooks/queries/use-account-list";
-import { useAccountId } from "@desktop/hooks/use-account-id";
 import { useAppStorage } from "@desktop/hooks/use-app-storage";
 import { useQueryKey } from "@desktop/hooks/use-query-key";
 import { useQueryClient } from "@tanstack/react-query";
@@ -19,8 +18,6 @@ export function useAuth() {
     "authenticated",
     false,
   );
-
-  const { setAccountId } = useAccountId();
 
   const { data: accounts } = useAccountList({
     enabled: authenticated,
@@ -42,6 +39,8 @@ export function useAuth() {
         session = data;
       }
 
+      if (!session) throw new Error("Failed to get session");
+
       await window.electron.store.set(
         `accounts.${session?.user.id}.active`,
         true,
@@ -51,7 +50,7 @@ export function useAuth() {
       // maybe the account was inactive.
       await window.electron.vault.start.all();
 
-      await setAccountId(session.user.id);
+      await window.electron.store.set("currentAccountId", session.user.id);
 
       await queryClient.invalidateQueries({
         queryKey: queryKeys.account.detail(),
@@ -61,8 +60,10 @@ export function useAuth() {
       posthog.reset();
       // Start a new session
       posthog.identify(session.user.id);
+
+      return session;
     },
-    [queryClient, setAccountId, queryKeys, posthog],
+    [queryClient, queryKeys, posthog],
   );
 
   const selectAccount = useCallback(
@@ -73,9 +74,15 @@ export function useAuth() {
 
       if (error || !data) throw error;
 
-      navigate({ to: "/app/loading" });
-      await accountChanged(data);
-      navigate({ to: "/app" });
+      navigate({ to: "/{-$accountId}/loading" });
+
+      const session = await accountChanged(data);
+      if (!session) return;
+
+      navigate({
+        to: "/{-$accountId}",
+        params: { accountId: session.user.id },
+      });
     },
     [accountChanged, navigate],
   );
@@ -97,6 +104,7 @@ export function useAuth() {
     if (remainingSessions?.length && remainingSessions[0]) {
       selectAccount(remainingSessions[0].session.token);
     } else {
+      await window.electron.store.set("currentAccountId", null);
       setAuthenticated(false);
       navigate({ to: "/auth" });
     }

--- a/apps/desktop/src/hooks/use-profile.ts
+++ b/apps/desktop/src/hooks/use-profile.ts
@@ -15,12 +15,12 @@ export function useProfile() {
     (userName: string | undefined, hostNameOverride?: string) => {
       if (userName)
         navigate({
-          to: "/app/{-$vaultId}/{-$hostName}/{-$userName}",
+          to: "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}",
           params: { hostName: hostNameOverride || hostName, userName },
         });
       else
         navigate({
-          to: "/app/{-$vaultId}/{-$hostName}",
+          to: "/{-$accountId}/{-$vaultId}/{-$hostName}",
           params: { hostName: hostNameOverride || hostName },
         });
     },
@@ -30,7 +30,7 @@ export function useProfile() {
   const changeHostName = useCallback(
     (hostName: string) => {
       navigate({
-        to: "/app/{-$vaultId}/{-$hostName}",
+        to: "/{-$accountId}/{-$vaultId}/{-$hostName}",
         params: { hostName: hostName },
       });
     },

--- a/apps/desktop/src/hooks/use-vault-id.ts
+++ b/apps/desktop/src/hooks/use-vault-id.ts
@@ -8,7 +8,7 @@ export function useVaultId() {
   const changeVault = useCallback(
     (id: string) => {
       navigate({
-        to: "/app/{-$vaultId}",
+        to: "/{-$accountId}/{-$vaultId}",
         params: {
           vaultId: id,
         },

--- a/apps/desktop/src/routeTree.gen.ts
+++ b/apps/desktop/src/routeTree.gen.ts
@@ -12,20 +12,20 @@
 
 import { Route as rootRoute } from './routes/__root'
 import { Route as AuthImport } from './routes/auth'
-import { Route as AppRouteImport } from './routes/app/route'
+import { Route as AccountIdRouteImport } from './routes/{-$accountId}/route'
 import { Route as IndexImport } from './routes/index'
-import { Route as AppIndexImport } from './routes/app/index'
-import { Route as AppLoadingImport } from './routes/app/loading'
-import { Route as AppVaultIdRouteImport } from './routes/app/{-$vaultId}/route'
-import { Route as AppVaultIdIndexImport } from './routes/app/{-$vaultId}/index'
-import { Route as AppVaultIdHostNameIndexImport } from './routes/app/{-$vaultId}/{-$hostName}/index'
-import { Route as AppVaultIdHostNameUserNameRouteImport } from './routes/app/{-$vaultId}/{-$hostName}/{-$userName}/route'
-import { Route as AppVaultIdHostNameUserNameIndexImport } from './routes/app/{-$vaultId}/{-$hostName}/{-$userName}/index'
-import { Route as AppVaultIdHostNameUserNameSettingsImport } from './routes/app/{-$vaultId}/{-$hostName}/{-$userName}/settings'
-import { Route as AppVaultIdHostNameUserNameFolderIdRouteImport } from './routes/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/route'
-import { Route as AppVaultIdHostNameUserNameFolderIdIndexImport } from './routes/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/index'
-import { Route as AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteImport } from './routes/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/route'
-import { Route as AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexImport } from './routes/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/index'
+import { Route as AccountIdIndexImport } from './routes/{-$accountId}/index'
+import { Route as AccountIdLoadingImport } from './routes/{-$accountId}/loading'
+import { Route as AccountIdVaultIdRouteImport } from './routes/{-$accountId}/{-$vaultId}/route'
+import { Route as AccountIdVaultIdIndexImport } from './routes/{-$accountId}/{-$vaultId}/index'
+import { Route as AccountIdVaultIdHostNameIndexImport } from './routes/{-$accountId}/{-$vaultId}/{-$hostName}/index'
+import { Route as AccountIdVaultIdHostNameUserNameRouteImport } from './routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/route'
+import { Route as AccountIdVaultIdHostNameUserNameIndexImport } from './routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/index'
+import { Route as AccountIdVaultIdHostNameUserNameSettingsImport } from './routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings'
+import { Route as AccountIdVaultIdHostNameUserNameFolderIdRouteImport } from './routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/route'
+import { Route as AccountIdVaultIdHostNameUserNameFolderIdIndexImport } from './routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/index'
+import { Route as AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteImport } from './routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/route'
+import { Route as AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexImport } from './routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/index'
 
 // Create/Update Routes
 
@@ -35,9 +35,9 @@ const AuthRoute = AuthImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
-const AppRouteRoute = AppRouteImport.update({
-  id: '/app',
-  path: '/app',
+const AccountIdRouteRoute = AccountIdRouteImport.update({
+  id: '/{-$accountId}',
+  path: '/{-$accountId}',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -47,85 +47,90 @@ const IndexRoute = IndexImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
-const AppIndexRoute = AppIndexImport.update({
+const AccountIdIndexRoute = AccountIdIndexImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => AppRouteRoute,
+  getParentRoute: () => AccountIdRouteRoute,
 } as any)
 
-const AppLoadingRoute = AppLoadingImport.update({
+const AccountIdLoadingRoute = AccountIdLoadingImport.update({
   id: '/loading',
   path: '/loading',
-  getParentRoute: () => AppRouteRoute,
+  getParentRoute: () => AccountIdRouteRoute,
 } as any)
 
-const AppVaultIdRouteRoute = AppVaultIdRouteImport.update({
+const AccountIdVaultIdRouteRoute = AccountIdVaultIdRouteImport.update({
   id: '/{-$vaultId}',
   path: '/{-$vaultId}',
-  getParentRoute: () => AppRouteRoute,
+  getParentRoute: () => AccountIdRouteRoute,
 } as any)
 
-const AppVaultIdIndexRoute = AppVaultIdIndexImport.update({
+const AccountIdVaultIdIndexRoute = AccountIdVaultIdIndexImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => AppVaultIdRouteRoute,
+  getParentRoute: () => AccountIdVaultIdRouteRoute,
 } as any)
 
-const AppVaultIdHostNameIndexRoute = AppVaultIdHostNameIndexImport.update({
-  id: '/{-$hostName}/',
-  path: '/{-$hostName}/',
-  getParentRoute: () => AppVaultIdRouteRoute,
-} as any)
+const AccountIdVaultIdHostNameIndexRoute =
+  AccountIdVaultIdHostNameIndexImport.update({
+    id: '/{-$hostName}/',
+    path: '/{-$hostName}/',
+    getParentRoute: () => AccountIdVaultIdRouteRoute,
+  } as any)
 
-const AppVaultIdHostNameUserNameRouteRoute =
-  AppVaultIdHostNameUserNameRouteImport.update({
+const AccountIdVaultIdHostNameUserNameRouteRoute =
+  AccountIdVaultIdHostNameUserNameRouteImport.update({
     id: '/{-$hostName}/{-$userName}',
     path: '/{-$hostName}/{-$userName}',
-    getParentRoute: () => AppVaultIdRouteRoute,
+    getParentRoute: () => AccountIdVaultIdRouteRoute,
   } as any)
 
-const AppVaultIdHostNameUserNameIndexRoute =
-  AppVaultIdHostNameUserNameIndexImport.update({
+const AccountIdVaultIdHostNameUserNameIndexRoute =
+  AccountIdVaultIdHostNameUserNameIndexImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => AppVaultIdHostNameUserNameRouteRoute,
+    getParentRoute: () => AccountIdVaultIdHostNameUserNameRouteRoute,
   } as any)
 
-const AppVaultIdHostNameUserNameSettingsRoute =
-  AppVaultIdHostNameUserNameSettingsImport.update({
+const AccountIdVaultIdHostNameUserNameSettingsRoute =
+  AccountIdVaultIdHostNameUserNameSettingsImport.update({
     id: '/settings',
     path: '/settings',
-    getParentRoute: () => AppVaultIdHostNameUserNameRouteRoute,
+    getParentRoute: () => AccountIdVaultIdHostNameUserNameRouteRoute,
   } as any)
 
-const AppVaultIdHostNameUserNameFolderIdRouteRoute =
-  AppVaultIdHostNameUserNameFolderIdRouteImport.update({
+const AccountIdVaultIdHostNameUserNameFolderIdRouteRoute =
+  AccountIdVaultIdHostNameUserNameFolderIdRouteImport.update({
     id: '/{-$folderId}',
     path: '/{-$folderId}',
-    getParentRoute: () => AppVaultIdHostNameUserNameRouteRoute,
+    getParentRoute: () => AccountIdVaultIdHostNameUserNameRouteRoute,
   } as any)
 
-const AppVaultIdHostNameUserNameFolderIdIndexRoute =
-  AppVaultIdHostNameUserNameFolderIdIndexImport.update({
+const AccountIdVaultIdHostNameUserNameFolderIdIndexRoute =
+  AccountIdVaultIdHostNameUserNameFolderIdIndexImport.update({
     id: '/',
     path: '/',
-    getParentRoute: () => AppVaultIdHostNameUserNameFolderIdRouteRoute,
+    getParentRoute: () => AccountIdVaultIdHostNameUserNameFolderIdRouteRoute,
   } as any)
 
-const AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute =
-  AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteImport.update({
-    id: '/{-$backupId}/{-$directoryId}',
-    path: '/{-$backupId}/{-$directoryId}',
-    getParentRoute: () => AppVaultIdHostNameUserNameFolderIdRouteRoute,
-  } as any)
+const AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute =
+  AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteImport.update(
+    {
+      id: '/{-$backupId}/{-$directoryId}',
+      path: '/{-$backupId}/{-$directoryId}',
+      getParentRoute: () => AccountIdVaultIdHostNameUserNameFolderIdRouteRoute,
+    } as any,
+  )
 
-const AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute =
-  AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexImport.update({
-    id: '/',
-    path: '/',
-    getParentRoute: () =>
-      AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute,
-  } as any)
+const AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute =
+  AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexImport.update(
+    {
+      id: '/',
+      path: '/',
+      getParentRoute: () =>
+        AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute,
+    } as any,
+  )
 
 // Populate the FileRoutesByPath interface
 
@@ -138,11 +143,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexImport
       parentRoute: typeof rootRoute
     }
-    '/app': {
-      id: '/app'
-      path: '/app'
-      fullPath: '/app'
-      preLoaderRoute: typeof AppRouteImport
+    '/{-$accountId}': {
+      id: '/{-$accountId}'
+      path: '/{-$accountId}'
+      fullPath: '/{-$accountId}'
+      preLoaderRoute: typeof AccountIdRouteImport
       parentRoute: typeof rootRoute
     }
     '/auth': {
@@ -152,290 +157,292 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthImport
       parentRoute: typeof rootRoute
     }
-    '/app/{-$vaultId}': {
-      id: '/app/{-$vaultId}'
+    '/{-$accountId}/{-$vaultId}': {
+      id: '/{-$accountId}/{-$vaultId}'
       path: '/{-$vaultId}'
-      fullPath: '/app/{-$vaultId}'
-      preLoaderRoute: typeof AppVaultIdRouteImport
-      parentRoute: typeof AppRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}'
+      preLoaderRoute: typeof AccountIdVaultIdRouteImport
+      parentRoute: typeof AccountIdRouteImport
     }
-    '/app/loading': {
-      id: '/app/loading'
+    '/{-$accountId}/loading': {
+      id: '/{-$accountId}/loading'
       path: '/loading'
-      fullPath: '/app/loading'
-      preLoaderRoute: typeof AppLoadingImport
-      parentRoute: typeof AppRouteImport
+      fullPath: '/{-$accountId}/loading'
+      preLoaderRoute: typeof AccountIdLoadingImport
+      parentRoute: typeof AccountIdRouteImport
     }
-    '/app/': {
-      id: '/app/'
+    '/{-$accountId}/': {
+      id: '/{-$accountId}/'
       path: '/'
-      fullPath: '/app/'
-      preLoaderRoute: typeof AppIndexImport
-      parentRoute: typeof AppRouteImport
+      fullPath: '/{-$accountId}/'
+      preLoaderRoute: typeof AccountIdIndexImport
+      parentRoute: typeof AccountIdRouteImport
     }
-    '/app/{-$vaultId}/': {
-      id: '/app/{-$vaultId}/'
+    '/{-$accountId}/{-$vaultId}/': {
+      id: '/{-$accountId}/{-$vaultId}/'
       path: '/'
-      fullPath: '/app/{-$vaultId}/'
-      preLoaderRoute: typeof AppVaultIdIndexImport
-      parentRoute: typeof AppVaultIdRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}/'
+      preLoaderRoute: typeof AccountIdVaultIdIndexImport
+      parentRoute: typeof AccountIdVaultIdRouteImport
     }
-    '/app/{-$vaultId}/{-$hostName}/{-$userName}': {
-      id: '/app/{-$vaultId}/{-$hostName}/{-$userName}'
+    '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}': {
+      id: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}'
       path: '/{-$hostName}/{-$userName}'
-      fullPath: '/app/{-$vaultId}/{-$hostName}/{-$userName}'
-      preLoaderRoute: typeof AppVaultIdHostNameUserNameRouteImport
-      parentRoute: typeof AppVaultIdRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}'
+      preLoaderRoute: typeof AccountIdVaultIdHostNameUserNameRouteImport
+      parentRoute: typeof AccountIdVaultIdRouteImport
     }
-    '/app/{-$vaultId}/{-$hostName}/': {
-      id: '/app/{-$vaultId}/{-$hostName}/'
+    '/{-$accountId}/{-$vaultId}/{-$hostName}/': {
+      id: '/{-$accountId}/{-$vaultId}/{-$hostName}/'
       path: '/{-$hostName}'
-      fullPath: '/app/{-$vaultId}/{-$hostName}'
-      preLoaderRoute: typeof AppVaultIdHostNameIndexImport
-      parentRoute: typeof AppVaultIdRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}/{-$hostName}'
+      preLoaderRoute: typeof AccountIdVaultIdHostNameIndexImport
+      parentRoute: typeof AccountIdVaultIdRouteImport
     }
-    '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}': {
-      id: '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
+    '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}': {
+      id: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
       path: '/{-$folderId}'
-      fullPath: '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
-      preLoaderRoute: typeof AppVaultIdHostNameUserNameFolderIdRouteImport
-      parentRoute: typeof AppVaultIdHostNameUserNameRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
+      preLoaderRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdRouteImport
+      parentRoute: typeof AccountIdVaultIdHostNameUserNameRouteImport
     }
-    '/app/{-$vaultId}/{-$hostName}/{-$userName}/settings': {
-      id: '/app/{-$vaultId}/{-$hostName}/{-$userName}/settings'
+    '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings': {
+      id: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings'
       path: '/settings'
-      fullPath: '/app/{-$vaultId}/{-$hostName}/{-$userName}/settings'
-      preLoaderRoute: typeof AppVaultIdHostNameUserNameSettingsImport
-      parentRoute: typeof AppVaultIdHostNameUserNameRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings'
+      preLoaderRoute: typeof AccountIdVaultIdHostNameUserNameSettingsImport
+      parentRoute: typeof AccountIdVaultIdHostNameUserNameRouteImport
     }
-    '/app/{-$vaultId}/{-$hostName}/{-$userName}/': {
-      id: '/app/{-$vaultId}/{-$hostName}/{-$userName}/'
+    '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/': {
+      id: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/'
       path: '/'
-      fullPath: '/app/{-$vaultId}/{-$hostName}/{-$userName}/'
-      preLoaderRoute: typeof AppVaultIdHostNameUserNameIndexImport
-      parentRoute: typeof AppVaultIdHostNameUserNameRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/'
+      preLoaderRoute: typeof AccountIdVaultIdHostNameUserNameIndexImport
+      parentRoute: typeof AccountIdVaultIdHostNameUserNameRouteImport
     }
-    '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/': {
-      id: '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/'
+    '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/': {
+      id: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/'
       path: '/'
-      fullPath: '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/'
-      preLoaderRoute: typeof AppVaultIdHostNameUserNameFolderIdIndexImport
-      parentRoute: typeof AppVaultIdHostNameUserNameFolderIdRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/'
+      preLoaderRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdIndexImport
+      parentRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdRouteImport
     }
-    '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}': {
-      id: '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
+    '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}': {
+      id: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
       path: '/{-$backupId}/{-$directoryId}'
-      fullPath: '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
-      preLoaderRoute: typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteImport
-      parentRoute: typeof AppVaultIdHostNameUserNameFolderIdRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
+      preLoaderRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteImport
+      parentRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdRouteImport
     }
-    '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/': {
-      id: '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/'
+    '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/': {
+      id: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/'
       path: '/'
-      fullPath: '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/'
-      preLoaderRoute: typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexImport
-      parentRoute: typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteImport
+      fullPath: '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/'
+      preLoaderRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexImport
+      parentRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteImport
     }
   }
 }
 
 // Create and export the route tree
 
-interface AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteChildren {
-  AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute: typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute
+interface AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteChildren {
+  AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute
 }
 
-const AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteChildren: AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteChildren =
+const AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteChildren: AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteChildren =
   {
-    AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute:
-      AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute,
+    AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute:
+      AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute,
   }
 
-const AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren =
-  AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute._addFileChildren(
-    AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteChildren,
+const AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren =
+  AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute._addFileChildren(
+    AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteChildren,
   )
 
-interface AppVaultIdHostNameUserNameFolderIdRouteRouteChildren {
-  AppVaultIdHostNameUserNameFolderIdIndexRoute: typeof AppVaultIdHostNameUserNameFolderIdIndexRoute
-  AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute: typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren
+interface AccountIdVaultIdHostNameUserNameFolderIdRouteRouteChildren {
+  AccountIdVaultIdHostNameUserNameFolderIdIndexRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdIndexRoute
+  AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren
 }
 
-const AppVaultIdHostNameUserNameFolderIdRouteRouteChildren: AppVaultIdHostNameUserNameFolderIdRouteRouteChildren =
+const AccountIdVaultIdHostNameUserNameFolderIdRouteRouteChildren: AccountIdVaultIdHostNameUserNameFolderIdRouteRouteChildren =
   {
-    AppVaultIdHostNameUserNameFolderIdIndexRoute:
-      AppVaultIdHostNameUserNameFolderIdIndexRoute,
-    AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute:
-      AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren,
+    AccountIdVaultIdHostNameUserNameFolderIdIndexRoute:
+      AccountIdVaultIdHostNameUserNameFolderIdIndexRoute,
+    AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRoute:
+      AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren,
   }
 
-const AppVaultIdHostNameUserNameFolderIdRouteRouteWithChildren =
-  AppVaultIdHostNameUserNameFolderIdRouteRoute._addFileChildren(
-    AppVaultIdHostNameUserNameFolderIdRouteRouteChildren,
+const AccountIdVaultIdHostNameUserNameFolderIdRouteRouteWithChildren =
+  AccountIdVaultIdHostNameUserNameFolderIdRouteRoute._addFileChildren(
+    AccountIdVaultIdHostNameUserNameFolderIdRouteRouteChildren,
   )
 
-interface AppVaultIdHostNameUserNameRouteRouteChildren {
-  AppVaultIdHostNameUserNameFolderIdRouteRoute: typeof AppVaultIdHostNameUserNameFolderIdRouteRouteWithChildren
-  AppVaultIdHostNameUserNameSettingsRoute: typeof AppVaultIdHostNameUserNameSettingsRoute
-  AppVaultIdHostNameUserNameIndexRoute: typeof AppVaultIdHostNameUserNameIndexRoute
+interface AccountIdVaultIdHostNameUserNameRouteRouteChildren {
+  AccountIdVaultIdHostNameUserNameFolderIdRouteRoute: typeof AccountIdVaultIdHostNameUserNameFolderIdRouteRouteWithChildren
+  AccountIdVaultIdHostNameUserNameSettingsRoute: typeof AccountIdVaultIdHostNameUserNameSettingsRoute
+  AccountIdVaultIdHostNameUserNameIndexRoute: typeof AccountIdVaultIdHostNameUserNameIndexRoute
 }
 
-const AppVaultIdHostNameUserNameRouteRouteChildren: AppVaultIdHostNameUserNameRouteRouteChildren =
+const AccountIdVaultIdHostNameUserNameRouteRouteChildren: AccountIdVaultIdHostNameUserNameRouteRouteChildren =
   {
-    AppVaultIdHostNameUserNameFolderIdRouteRoute:
-      AppVaultIdHostNameUserNameFolderIdRouteRouteWithChildren,
-    AppVaultIdHostNameUserNameSettingsRoute:
-      AppVaultIdHostNameUserNameSettingsRoute,
-    AppVaultIdHostNameUserNameIndexRoute: AppVaultIdHostNameUserNameIndexRoute,
+    AccountIdVaultIdHostNameUserNameFolderIdRouteRoute:
+      AccountIdVaultIdHostNameUserNameFolderIdRouteRouteWithChildren,
+    AccountIdVaultIdHostNameUserNameSettingsRoute:
+      AccountIdVaultIdHostNameUserNameSettingsRoute,
+    AccountIdVaultIdHostNameUserNameIndexRoute:
+      AccountIdVaultIdHostNameUserNameIndexRoute,
   }
 
-const AppVaultIdHostNameUserNameRouteRouteWithChildren =
-  AppVaultIdHostNameUserNameRouteRoute._addFileChildren(
-    AppVaultIdHostNameUserNameRouteRouteChildren,
+const AccountIdVaultIdHostNameUserNameRouteRouteWithChildren =
+  AccountIdVaultIdHostNameUserNameRouteRoute._addFileChildren(
+    AccountIdVaultIdHostNameUserNameRouteRouteChildren,
   )
 
-interface AppVaultIdRouteRouteChildren {
-  AppVaultIdIndexRoute: typeof AppVaultIdIndexRoute
-  AppVaultIdHostNameUserNameRouteRoute: typeof AppVaultIdHostNameUserNameRouteRouteWithChildren
-  AppVaultIdHostNameIndexRoute: typeof AppVaultIdHostNameIndexRoute
+interface AccountIdVaultIdRouteRouteChildren {
+  AccountIdVaultIdIndexRoute: typeof AccountIdVaultIdIndexRoute
+  AccountIdVaultIdHostNameUserNameRouteRoute: typeof AccountIdVaultIdHostNameUserNameRouteRouteWithChildren
+  AccountIdVaultIdHostNameIndexRoute: typeof AccountIdVaultIdHostNameIndexRoute
 }
 
-const AppVaultIdRouteRouteChildren: AppVaultIdRouteRouteChildren = {
-  AppVaultIdIndexRoute: AppVaultIdIndexRoute,
-  AppVaultIdHostNameUserNameRouteRoute:
-    AppVaultIdHostNameUserNameRouteRouteWithChildren,
-  AppVaultIdHostNameIndexRoute: AppVaultIdHostNameIndexRoute,
+const AccountIdVaultIdRouteRouteChildren: AccountIdVaultIdRouteRouteChildren = {
+  AccountIdVaultIdIndexRoute: AccountIdVaultIdIndexRoute,
+  AccountIdVaultIdHostNameUserNameRouteRoute:
+    AccountIdVaultIdHostNameUserNameRouteRouteWithChildren,
+  AccountIdVaultIdHostNameIndexRoute: AccountIdVaultIdHostNameIndexRoute,
 }
 
-const AppVaultIdRouteRouteWithChildren = AppVaultIdRouteRoute._addFileChildren(
-  AppVaultIdRouteRouteChildren,
-)
+const AccountIdVaultIdRouteRouteWithChildren =
+  AccountIdVaultIdRouteRoute._addFileChildren(
+    AccountIdVaultIdRouteRouteChildren,
+  )
 
-interface AppRouteRouteChildren {
-  AppVaultIdRouteRoute: typeof AppVaultIdRouteRouteWithChildren
-  AppLoadingRoute: typeof AppLoadingRoute
-  AppIndexRoute: typeof AppIndexRoute
+interface AccountIdRouteRouteChildren {
+  AccountIdVaultIdRouteRoute: typeof AccountIdVaultIdRouteRouteWithChildren
+  AccountIdLoadingRoute: typeof AccountIdLoadingRoute
+  AccountIdIndexRoute: typeof AccountIdIndexRoute
 }
 
-const AppRouteRouteChildren: AppRouteRouteChildren = {
-  AppVaultIdRouteRoute: AppVaultIdRouteRouteWithChildren,
-  AppLoadingRoute: AppLoadingRoute,
-  AppIndexRoute: AppIndexRoute,
+const AccountIdRouteRouteChildren: AccountIdRouteRouteChildren = {
+  AccountIdVaultIdRouteRoute: AccountIdVaultIdRouteRouteWithChildren,
+  AccountIdLoadingRoute: AccountIdLoadingRoute,
+  AccountIdIndexRoute: AccountIdIndexRoute,
 }
 
-const AppRouteRouteWithChildren = AppRouteRoute._addFileChildren(
-  AppRouteRouteChildren,
+const AccountIdRouteRouteWithChildren = AccountIdRouteRoute._addFileChildren(
+  AccountIdRouteRouteChildren,
 )
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/app': typeof AppRouteRouteWithChildren
+  '/{-$accountId}': typeof AccountIdRouteRouteWithChildren
   '/auth': typeof AuthRoute
-  '/app/{-$vaultId}': typeof AppVaultIdRouteRouteWithChildren
-  '/app/loading': typeof AppLoadingRoute
-  '/app/': typeof AppIndexRoute
-  '/app/{-$vaultId}/': typeof AppVaultIdIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}': typeof AppVaultIdHostNameUserNameRouteRouteWithChildren
-  '/app/{-$vaultId}/{-$hostName}': typeof AppVaultIdHostNameIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}': typeof AppVaultIdHostNameUserNameFolderIdRouteRouteWithChildren
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/settings': typeof AppVaultIdHostNameUserNameSettingsRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/': typeof AppVaultIdHostNameUserNameIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/': typeof AppVaultIdHostNameUserNameFolderIdIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}': typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/': typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute
+  '/{-$accountId}/{-$vaultId}': typeof AccountIdVaultIdRouteRouteWithChildren
+  '/{-$accountId}/loading': typeof AccountIdLoadingRoute
+  '/{-$accountId}/': typeof AccountIdIndexRoute
+  '/{-$accountId}/{-$vaultId}/': typeof AccountIdVaultIdIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}': typeof AccountIdVaultIdHostNameUserNameRouteRouteWithChildren
+  '/{-$accountId}/{-$vaultId}/{-$hostName}': typeof AccountIdVaultIdHostNameIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}': typeof AccountIdVaultIdHostNameUserNameFolderIdRouteRouteWithChildren
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings': typeof AccountIdVaultIdHostNameUserNameSettingsRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/': typeof AccountIdVaultIdHostNameUserNameIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/': typeof AccountIdVaultIdHostNameUserNameFolderIdIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}': typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/': typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute
 }
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/auth': typeof AuthRoute
-  '/app/loading': typeof AppLoadingRoute
-  '/app': typeof AppIndexRoute
-  '/app/{-$vaultId}': typeof AppVaultIdIndexRoute
-  '/app/{-$vaultId}/{-$hostName}': typeof AppVaultIdHostNameIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/settings': typeof AppVaultIdHostNameUserNameSettingsRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}': typeof AppVaultIdHostNameUserNameIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}': typeof AppVaultIdHostNameUserNameFolderIdIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}': typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute
+  '/{-$accountId}/loading': typeof AccountIdLoadingRoute
+  '/{-$accountId}': typeof AccountIdIndexRoute
+  '/{-$accountId}/{-$vaultId}': typeof AccountIdVaultIdIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}': typeof AccountIdVaultIdHostNameIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings': typeof AccountIdVaultIdHostNameUserNameSettingsRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}': typeof AccountIdVaultIdHostNameUserNameIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}': typeof AccountIdVaultIdHostNameUserNameFolderIdIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}': typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute
 }
 
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
-  '/app': typeof AppRouteRouteWithChildren
+  '/{-$accountId}': typeof AccountIdRouteRouteWithChildren
   '/auth': typeof AuthRoute
-  '/app/{-$vaultId}': typeof AppVaultIdRouteRouteWithChildren
-  '/app/loading': typeof AppLoadingRoute
-  '/app/': typeof AppIndexRoute
-  '/app/{-$vaultId}/': typeof AppVaultIdIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}': typeof AppVaultIdHostNameUserNameRouteRouteWithChildren
-  '/app/{-$vaultId}/{-$hostName}/': typeof AppVaultIdHostNameIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}': typeof AppVaultIdHostNameUserNameFolderIdRouteRouteWithChildren
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/settings': typeof AppVaultIdHostNameUserNameSettingsRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/': typeof AppVaultIdHostNameUserNameIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/': typeof AppVaultIdHostNameUserNameFolderIdIndexRoute
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}': typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren
-  '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/': typeof AppVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute
+  '/{-$accountId}/{-$vaultId}': typeof AccountIdVaultIdRouteRouteWithChildren
+  '/{-$accountId}/loading': typeof AccountIdLoadingRoute
+  '/{-$accountId}/': typeof AccountIdIndexRoute
+  '/{-$accountId}/{-$vaultId}/': typeof AccountIdVaultIdIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}': typeof AccountIdVaultIdHostNameUserNameRouteRouteWithChildren
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/': typeof AccountIdVaultIdHostNameIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}': typeof AccountIdVaultIdHostNameUserNameFolderIdRouteRouteWithChildren
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings': typeof AccountIdVaultIdHostNameUserNameSettingsRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/': typeof AccountIdVaultIdHostNameUserNameIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/': typeof AccountIdVaultIdHostNameUserNameFolderIdIndexRoute
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}': typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdRouteRouteWithChildren
+  '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/': typeof AccountIdVaultIdHostNameUserNameFolderIdBackupIdDirectoryIdIndexRoute
 }
 
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
-    | '/app'
+    | '/{-$accountId}'
     | '/auth'
-    | '/app/{-$vaultId}'
-    | '/app/loading'
-    | '/app/'
-    | '/app/{-$vaultId}/'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}'
-    | '/app/{-$vaultId}/{-$hostName}'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/settings'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/'
+    | '/{-$accountId}/{-$vaultId}'
+    | '/{-$accountId}/loading'
+    | '/{-$accountId}/'
+    | '/{-$accountId}/{-$vaultId}/'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
     | '/auth'
-    | '/app/loading'
-    | '/app'
-    | '/app/{-$vaultId}'
-    | '/app/{-$vaultId}/{-$hostName}'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/settings'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
+    | '/{-$accountId}/loading'
+    | '/{-$accountId}'
+    | '/{-$accountId}/{-$vaultId}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
   id:
     | '__root__'
     | '/'
-    | '/app'
+    | '/{-$accountId}'
     | '/auth'
-    | '/app/{-$vaultId}'
-    | '/app/loading'
-    | '/app/'
-    | '/app/{-$vaultId}/'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}'
-    | '/app/{-$vaultId}/{-$hostName}/'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/settings'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
-    | '/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/'
+    | '/{-$accountId}/{-$vaultId}'
+    | '/{-$accountId}/loading'
+    | '/{-$accountId}/'
+    | '/{-$accountId}/{-$vaultId}/'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}'
+    | '/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/'
   fileRoutesById: FileRoutesById
 }
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  AppRouteRoute: typeof AppRouteRouteWithChildren
+  AccountIdRouteRoute: typeof AccountIdRouteRouteWithChildren
   AuthRoute: typeof AuthRoute
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  AppRouteRoute: AppRouteRouteWithChildren,
+  AccountIdRouteRoute: AccountIdRouteRouteWithChildren,
   AuthRoute: AuthRoute,
 }
 
@@ -450,88 +457,88 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/",
-        "/app",
+        "/{-$accountId}",
         "/auth"
       ]
     },
     "/": {
       "filePath": "index.tsx"
     },
-    "/app": {
-      "filePath": "app/route.tsx",
+    "/{-$accountId}": {
+      "filePath": "{-$accountId}/route.tsx",
       "children": [
-        "/app/{-$vaultId}",
-        "/app/loading",
-        "/app/"
+        "/{-$accountId}/{-$vaultId}",
+        "/{-$accountId}/loading",
+        "/{-$accountId}/"
       ]
     },
     "/auth": {
       "filePath": "auth.tsx"
     },
-    "/app/{-$vaultId}": {
-      "filePath": "app/{-$vaultId}/route.tsx",
-      "parent": "/app",
+    "/{-$accountId}/{-$vaultId}": {
+      "filePath": "{-$accountId}/{-$vaultId}/route.tsx",
+      "parent": "/{-$accountId}",
       "children": [
-        "/app/{-$vaultId}/",
-        "/app/{-$vaultId}/{-$hostName}/{-$userName}",
-        "/app/{-$vaultId}/{-$hostName}/"
+        "/{-$accountId}/{-$vaultId}/",
+        "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}",
+        "/{-$accountId}/{-$vaultId}/{-$hostName}/"
       ]
     },
-    "/app/loading": {
-      "filePath": "app/loading.tsx",
-      "parent": "/app"
+    "/{-$accountId}/loading": {
+      "filePath": "{-$accountId}/loading.tsx",
+      "parent": "/{-$accountId}"
     },
-    "/app/": {
-      "filePath": "app/index.tsx",
-      "parent": "/app"
+    "/{-$accountId}/": {
+      "filePath": "{-$accountId}/index.tsx",
+      "parent": "/{-$accountId}"
     },
-    "/app/{-$vaultId}/": {
-      "filePath": "app/{-$vaultId}/index.tsx",
-      "parent": "/app/{-$vaultId}"
+    "/{-$accountId}/{-$vaultId}/": {
+      "filePath": "{-$accountId}/{-$vaultId}/index.tsx",
+      "parent": "/{-$accountId}/{-$vaultId}"
     },
-    "/app/{-$vaultId}/{-$hostName}/{-$userName}": {
-      "filePath": "app/{-$vaultId}/{-$hostName}/{-$userName}/route.tsx",
-      "parent": "/app/{-$vaultId}",
+    "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}": {
+      "filePath": "{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/route.tsx",
+      "parent": "/{-$accountId}/{-$vaultId}",
       "children": [
-        "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
-        "/app/{-$vaultId}/{-$hostName}/{-$userName}/settings",
-        "/app/{-$vaultId}/{-$hostName}/{-$userName}/"
+        "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
+        "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings",
+        "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/"
       ]
     },
-    "/app/{-$vaultId}/{-$hostName}/": {
-      "filePath": "app/{-$vaultId}/{-$hostName}/index.tsx",
-      "parent": "/app/{-$vaultId}"
+    "/{-$accountId}/{-$vaultId}/{-$hostName}/": {
+      "filePath": "{-$accountId}/{-$vaultId}/{-$hostName}/index.tsx",
+      "parent": "/{-$accountId}/{-$vaultId}"
     },
-    "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}": {
-      "filePath": "app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/route.tsx",
-      "parent": "/app/{-$vaultId}/{-$hostName}/{-$userName}",
+    "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}": {
+      "filePath": "{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/route.tsx",
+      "parent": "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}",
       "children": [
-        "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/",
-        "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}"
+        "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/",
+        "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}"
       ]
     },
-    "/app/{-$vaultId}/{-$hostName}/{-$userName}/settings": {
-      "filePath": "app/{-$vaultId}/{-$hostName}/{-$userName}/settings.tsx",
-      "parent": "/app/{-$vaultId}/{-$hostName}/{-$userName}"
+    "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings": {
+      "filePath": "{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings.tsx",
+      "parent": "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}"
     },
-    "/app/{-$vaultId}/{-$hostName}/{-$userName}/": {
-      "filePath": "app/{-$vaultId}/{-$hostName}/{-$userName}/index.tsx",
-      "parent": "/app/{-$vaultId}/{-$hostName}/{-$userName}"
+    "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/": {
+      "filePath": "{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/index.tsx",
+      "parent": "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}"
     },
-    "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/": {
-      "filePath": "app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/index.tsx",
-      "parent": "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}"
+    "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/": {
+      "filePath": "{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/index.tsx",
+      "parent": "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}"
     },
-    "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}": {
-      "filePath": "app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/route.tsx",
-      "parent": "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
+    "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}": {
+      "filePath": "{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/route.tsx",
+      "parent": "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
       "children": [
-        "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/"
+        "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/"
       ]
     },
-    "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/": {
-      "filePath": "app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/index.tsx",
-      "parent": "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}"
+    "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/": {
+      "filePath": "{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/index.tsx",
+      "parent": "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}"
     }
   }
 }

--- a/apps/desktop/src/routes/index.tsx
+++ b/apps/desktop/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { useAccountId } from "@desktop/hooks/use-account-id";
 import { useAuth } from "@desktop/hooks/use-auth";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
@@ -9,15 +10,26 @@ export const Route = createFileRoute("/")({
 function RouteComponent() {
   const navigate = useNavigate();
 
+  const { accountId } = useAccountId();
   const { authenticated } = useAuth();
 
   useEffect(() => {
-    if (!authenticated) {
+    const accountId = window.electron.store.get("currentAccountId") as
+      | string
+      | undefined
+      | null;
+
+    if (!authenticated || !accountId) {
       navigate({ to: "/auth", replace: true });
-    } else {
-      navigate({ to: "/app", replace: true });
+      return;
     }
-  }, [navigate, authenticated]);
+
+    navigate({
+      to: "/{-$accountId}",
+      params: { accountId },
+      replace: true,
+    });
+  }, [navigate, authenticated, accountId]);
 
   return null;
 }

--- a/apps/desktop/src/routes/index.tsx
+++ b/apps/desktop/src/routes/index.tsx
@@ -1,4 +1,3 @@
-import { useAccountId } from "@desktop/hooks/use-account-id";
 import { useAuth } from "@desktop/hooks/use-auth";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useEffect } from "react";
@@ -10,7 +9,6 @@ export const Route = createFileRoute("/")({
 function RouteComponent() {
   const navigate = useNavigate();
 
-  const { accountId } = useAccountId();
   const { authenticated } = useAuth();
 
   useEffect(() => {
@@ -29,7 +27,7 @@ function RouteComponent() {
       params: { accountId },
       replace: true,
     });
-  }, [navigate, authenticated, accountId]);
+  }, [navigate, authenticated]);
 
   return null;
 }

--- a/apps/desktop/src/routes/{-$accountId}/index.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/index.tsx
@@ -9,7 +9,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { CloudAlertIcon, PlusIcon } from "lucide-react";
 import { useEffect } from "react";
 
-export const Route = createFileRoute("/app/")({
+export const Route = createFileRoute("/{-$accountId}/")({
   component: RouteComponent,
 });
 
@@ -34,7 +34,7 @@ function RouteComponent() {
     }
 
     navigate({
-      to: "/app/{-$vaultId}",
+      to: "/{-$accountId}/{-$vaultId}",
       params: (params) => ({
         ...params,
         vaultId: lastUsedVaultId || vaults[0]?.id || "",

--- a/apps/desktop/src/routes/{-$accountId}/loading.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/loading.tsx
@@ -1,7 +1,7 @@
 import { VaultHome } from "@desktop/components/vaults/home";
 import { createFileRoute } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/app/loading")({
+export const Route = createFileRoute("/{-$accountId}/loading")({
   component: RouteComponent,
 });
 

--- a/apps/desktop/src/routes/{-$accountId}/route.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/route.tsx
@@ -3,7 +3,7 @@ import { useSubscriptionWatch } from "@desktop/hooks/use-subscription-watch";
 import { useVaultCache } from "@desktop/hooks/use-vault-cache";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
-export const Route = createFileRoute("/app")({
+export const Route = createFileRoute("/{-$accountId}")({
   component: RouteComponent,
 });
 

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/index.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/index.tsx
@@ -3,7 +3,7 @@ import { useLocalProfile } from "@desktop/hooks/use-local-profile";
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect } from "react";
 
-export const Route = createFileRoute("/app/{-$vaultId}/")({
+export const Route = createFileRoute("/{-$accountId}/{-$vaultId}/")({
   component: RouteComponent,
 });
 
@@ -16,7 +16,7 @@ function RouteComponent() {
     if (!localHostName) return;
 
     navigate({
-      to: "/app/{-$vaultId}/{-$hostName}",
+      to: "/{-$accountId}/{-$vaultId}/{-$hostName}",
       params: (params) => ({
         ...params,
         hostName: localHostName,

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/route.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/route.tsx
@@ -7,7 +7,7 @@ import { useAccountStorage } from "@desktop/hooks/use-account-storage";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 import { useEffect } from "react";
 
-export const Route = createFileRoute("/app/{-$vaultId}")({
+export const Route = createFileRoute("/{-$accountId}/{-$vaultId}")({
   component: RouteComponent,
 });
 

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/index.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/index.tsx
@@ -5,7 +5,9 @@ import { useProfile } from "@desktop/hooks/use-profile";
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect } from "react";
 
-export const Route = createFileRoute("/app/{-$vaultId}/{-$hostName}/")({
+export const Route = createFileRoute(
+  "/{-$accountId}/{-$vaultId}/{-$hostName}/",
+)({
   component: RouteComponent,
 });
 
@@ -24,7 +26,7 @@ function RouteComponent() {
 
     if (!profile)
       navigate({
-        to: "/app/{-$vaultId}",
+        to: "/{-$accountId}/{-$vaultId}",
         replace: true,
       });
     else {
@@ -33,7 +35,7 @@ function RouteComponent() {
       );
 
       navigate({
-        to: "/app/{-$vaultId}/{-$hostName}/{-$userName}",
+        to: "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}",
         params: (params) => ({
           ...params,
           userName: localUser

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/index.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/index.tsx
@@ -5,7 +5,7 @@ import { useVaultStatus } from "@desktop/hooks/queries/use-vault-status";
 import { createFileRoute } from "@tanstack/react-router";
 
 export const Route = createFileRoute(
-  "/app/{-$vaultId}/{-$hostName}/{-$userName}/",
+  "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/",
 )({
   component: RouteComponent,
 });

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/route.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/route.tsx
@@ -11,7 +11,7 @@ import { useTaskbarProgress } from "@desktop/hooks/use-taskbar-progress";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute(
-  "/app/{-$vaultId}/{-$hostName}/{-$userName}",
+  "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}",
 )({
   component: RouteComponent,
 });

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings.tsx
@@ -17,7 +17,7 @@ import { HomeIcon } from "lucide-react";
 import { useState } from "react";
 
 export const Route = createFileRoute(
-  "/app/{-$vaultId}/{-$hostName}/{-$userName}/settings",
+  "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/settings",
 )({
   component: RouteComponent,
 });
@@ -45,7 +45,7 @@ function RouteComponent() {
       >
         {vault ? (
           <Button
-            render={<Link to="/app/{-$vaultId}/{-$hostName}/{-$userName}" />}
+            render={<Link to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}" />}
             nativeButton={false}
             variant="outline"
             size="sm"

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/index.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/index.tsx
@@ -28,7 +28,7 @@ import {
 import animation from "/animations/backup.lottie?url";
 
 export const Route = createFileRoute(
-  "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/",
+  "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/",
 )({
   component: RouteComponent,
 });
@@ -68,7 +68,9 @@ function RouteComponent() {
         }
       >
         <Button
-          render={<Link to="/app/{-$vaultId}/{-$hostName}/{-$userName}" />}
+          render={
+            <Link to="/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}" />
+          }
           nativeButton={false}
           variant="outline"
           size="sm"

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/route.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/route.tsx
@@ -4,7 +4,7 @@ import { RenameBackupDialog } from "@desktop/components/dialogs/rename-backup";
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute(
-  "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
+  "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
 )({
   component: RouteComponent,
 });

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/index.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/index.tsx
@@ -15,7 +15,7 @@ import { useRef } from "react";
 import { z } from "zod";
 
 export const Route = createFileRoute(
-  "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/",
+  "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/",
 )({
   component: RouteComponent,
   validateSearch: z.object({
@@ -55,7 +55,7 @@ function RouteComponent() {
                 {
                   id: "folder",
                   text: folder.name || "",
-                  href: "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/",
+                  href: "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/",
                 },
                 {
                   id: "backup",
@@ -63,7 +63,7 @@ function RouteComponent() {
                   href:
                     !path || !path.length
                       ? undefined
-                      : "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
+                      : "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
                   params: (params) => ({
                     ...params,
                     directoryId: backup.rootID,
@@ -76,7 +76,7 @@ function RouteComponent() {
                       href:
                         index === path.length - 1
                           ? undefined
-                          : "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
+                          : "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
                       params: (params: Record<string, string>) => ({
                         ...params,
                         directoryId: objectId,
@@ -94,7 +94,7 @@ function RouteComponent() {
           onClick={() => {
             if (path && path.length)
               navigate({
-                to: "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
+                to: "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
                 params: (params) => ({
                   ...params,
                   directoryId:
@@ -106,7 +106,7 @@ function RouteComponent() {
               });
             else
               navigate({
-                to: "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
+                to: "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}",
               });
           }}
           size="sm"

--- a/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/route.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}/route.tsx
@@ -2,7 +2,7 @@ import { RestoreDirectoryDialog } from "@desktop/components/dialogs/restore-dire
 import { createFileRoute, Outlet } from "@tanstack/react-router";
 
 export const Route = createFileRoute(
-  "/app/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
+  "/{-$accountId}/{-$vaultId}/{-$hostName}/{-$userName}/{-$folderId}/{-$backupId}/{-$directoryId}",
 )({
   component: RouteComponent,
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Move account state into the URL by scoping all app routes under "/{-$accountId}". This enables account-specific deep links and prevents loading loops on auth errors.

- **Refactors**
  - Replaced "/app" routes with account-scoped paths and updated the generated route tree.
  - Updated all Link/navigate calls, breadcrumbs, and sidebar active checks to include `accountId`.
  - `useAccountId` now reads `accountId` from route params (removed setter and an unused variable).
  - Auth flow sets `currentAccountId` in the Electron store, navigates to "/{-$accountId}/loading" then "/{-$accountId}", redirects to "/" if session retrieval fails to avoid infinite loading, and clears it on sign out.
  - Root "/" redirect now sends authenticated users to "/{-$accountId}" (else "/auth").

<sup>Written for commit 6f70c172d4aac6ae62273391daffa2e83b899b93. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

