### PR TITLE
fix: invalid field for ssl verification

### DIFF
--- a/apps/desktop/src/components/forms/providers/s3-compatible.tsx
+++ b/apps/desktop/src/components/forms/providers/s3-compatible.tsx
@@ -91,8 +91,10 @@ export function S3CompatibleForm({
       <form.AppField name="disableTls">
         {(field) => <field.Switch label={{ title: t("disableTls.label") }} />}
       </form.AppField>
-      <form.AppField name="disableSsl">
-        {(field) => <field.Switch label={{ title: t("disableSsl.label") }} />}
+      <form.AppField name="disableTlsVerification">
+        {(field) => (
+          <field.Switch label={{ title: t("disableTlsVerification.label") }} />
+        )}
       </form.AppField>
       <CreateVaultAlerts form={form} action={action} />
       <ProviderSubmitButton action={action} form={form} />

--- a/apps/desktop/src/hooks/forms/providers/use-s3-compatible-form.ts
+++ b/apps/desktop/src/hooks/forms/providers/use-s3-compatible-form.ts
@@ -28,7 +28,7 @@ export function useS3CompatibleForm({
       sessionToken: "",
       prefix: "",
       region: "",
-      disableSsl: false,
+      disableTlsVerification: false,
       disableTls: false,
       ...config,
     } as ZS3CompatibleConfigType,

--- a/apps/electron/src/vault/mapping.test.ts
+++ b/apps/electron/src/vault/mapping.test.ts
@@ -59,7 +59,7 @@ describe("mapConfigFields", () => {
       bucket: "my-bucket",
       region: "us-east-1",
       doNotUseTLS: true,
-      doNotVerifySSL: false,
+      doNotVerifyTLS: false,
     });
   });
 

--- a/apps/electron/src/vault/mapping.test.ts
+++ b/apps/electron/src/vault/mapping.test.ts
@@ -50,7 +50,7 @@ describe("mapConfigFields", () => {
       bucket: "my-bucket",
       region: "us-east-1",
       disableTls: true,
-      disableSsl: false,
+      disableTlsVerification: false,
     });
 
     expect(result).toEqual({

--- a/libs/constants/src/providers.ts
+++ b/libs/constants/src/providers.ts
@@ -32,7 +32,7 @@ const s3Base = {
     accessKeyType: "accessKeyID",
     accessKeySecret: "secretAccessKey",
     disableTls: "doNotUseTLS",
-    disableSsl: "doNotVerifyTLS",
+    disableTlsVerification: "doNotVerifyTLS",
   },
 };
 

--- a/libs/constants/src/providers.ts
+++ b/libs/constants/src/providers.ts
@@ -32,7 +32,7 @@ const s3Base = {
     accessKeyType: "accessKeyID",
     accessKeySecret: "secretAccessKey",
     disableTls: "doNotUseTLS",
-    disableSsl: "doNotVerifySSL",
+    disableSsl: "doNotVerifyTLS",
   },
 };
 

--- a/libs/schemas/src/providers.ts
+++ b/libs/schemas/src/providers.ts
@@ -28,7 +28,7 @@ export const ZS3CompatibleConfig = ZS3Config.merge(
   z.object({
     region: z.string().max(128).optional(),
     disableTls: z.boolean(),
-    disableSsl: z.boolean(),
+    disableTlsVerification: z.boolean(),
   }),
 );
 

--- a/locales/en/vault.json
+++ b/locales/en/vault.json
@@ -174,7 +174,7 @@
           "label": "Use insecure HTTP connection"
         },
         "disableTlsVerification": {
-          "label": "Disable TSL certificate verification"
+          "label": "Disable TLS certificate verification"
         }
       }
     },

--- a/locales/en/vault.json
+++ b/locales/en/vault.json
@@ -135,12 +135,6 @@
         "prefix": {
           "label": "Key prefix",
           "placeholder": "backup/"
-        },
-        "disableTls": {
-          "label": "Disable TLS"
-        },
-        "disableTlsVerification": {
-          "label": "Disable SSL Verification"
         }
       }
     },
@@ -177,10 +171,10 @@
           "placeholder": "backup/"
         },
         "disableTls": {
-          "label": "Disable TLS"
+          "label": "Use insecure HTTP connection"
         },
         "disableTlsVerification": {
-          "label": "Disable SSL Verification"
+          "label": "Disable TSL certificate verification"
         }
       }
     },

--- a/locales/en/vault.json
+++ b/locales/en/vault.json
@@ -139,7 +139,7 @@
         "disableTls": {
           "label": "Disable TLS"
         },
-        "disableSsl": {
+        "disableTlsVerification": {
           "label": "Disable SSL Verification"
         }
       }
@@ -179,7 +179,7 @@
         "disableTls": {
           "label": "Disable TLS"
         },
-        "disableSsl": {
+        "disableTlsVerification": {
           "label": "Disable SSL Verification"
         }
       }


### PR DESCRIPTION
Closes #186 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the invalid SSL/TLS verification flag for S3-compatible providers by replacing `disableSsl` with `disableTlsVerification` and mapping it to backend `doNotVerifyTLS`. Closes #186.

- **Bug Fixes**
  - Renamed field across form, schema, defaults, and tests to `disableTlsVerification`.
  - Updated provider mapping to send `doNotVerifyTLS` to the backend.
  - Clarified labels and fixed a typo: TLS toggle is "Use insecure HTTP connection"; verification toggle is "Disable TLS certificate verification".

<sup>Written for commit 5038ed7608a97c228dfc02d6ac80b74765392bd3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

