### PR TITLE
refactor: migrate all relative imports

### DIFF
--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,3 +1,4 @@
+import { trackAffiliateSignup } from "@api/lib/affiliate";
 import { getPostHog, posthog } from "@api/lib/posthog";
 import { electron } from "@better-auth/electron";
 import { APP_ID_ORIGIN } from "@blinkdisk/constants/app";
@@ -20,7 +21,6 @@ import { betterAuth } from "better-auth";
 import { APIError, createAuthMiddleware } from "better-auth/api";
 import { magicLink } from "better-auth/plugins";
 import { Kysely } from "kysely";
-import { trackAffiliateSignup } from "./lib/affiliate";
 
 const cookieSettings = {
   attributes: {

--- a/apps/desktop/src/components/accounts/select-dropdown.tsx
+++ b/apps/desktop/src/components/accounts/select-dropdown.tsx
@@ -1,3 +1,4 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
 import {
   DropdownMenu,
@@ -11,7 +12,6 @@ import { AccountPreview } from "@desktop/components/accounts/preview";
 import { useAccountList } from "@desktop/hooks/queries/use-account-list";
 import { useAccountId } from "@desktop/hooks/use-account-id";
 import { useAuth } from "@desktop/hooks/use-auth";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
 import { UserPlusIcon } from "lucide-react";
 import { ReactElement } from "react";
 

--- a/apps/desktop/src/components/cron/constants.ts
+++ b/apps/desktop/src/components/cron/constants.ts
@@ -2,7 +2,7 @@
 // Original copyright (c) 2021 Xavier Rutayisire
 // https://github.com/xrutayisire/react-js-cron
 
-import { ShortcutsValues, Unit } from "./types";
+import { ShortcutsValues, Unit } from "@desktop/components/cron/types";
 
 export const SUPPORTED_SHORTCUTS: ShortcutsValues[] = [
   {

--- a/apps/desktop/src/components/cron/converter.ts
+++ b/apps/desktop/src/components/cron/converter.ts
@@ -21,8 +21,14 @@ import {
   Shortcuts,
   ShortcutsType,
   Unit,
-} from "./types";
-import { convertStringToNumber, dedup, range, setError, sort } from "./utils";
+} from "@desktop/components/cron/types";
+import {
+  convertStringToNumber,
+  dedup,
+  range,
+  setError,
+  sort,
+} from "@desktop/components/cron/utils";
 
 /**
  * Set values from cron string

--- a/apps/desktop/src/components/cron/fields/hours.tsx
+++ b/apps/desktop/src/components/cron/fields/hours.tsx
@@ -2,10 +2,10 @@
 // Original copyright (c) 2021 Xavier Rutayisire
 // https://github.com/xrutayisire/react-js-cron
 
+import { UNITS } from "@desktop/components/cron/constants";
 import { CustomSelect } from "@desktop/components/cron/fields/select";
-import { UNITS } from "../constants";
-import { DEFAULT_LOCALE_EN } from "../locale";
-import { HoursProps } from "../types";
+import { DEFAULT_LOCALE_EN } from "@desktop/components/cron/locale";
+import { HoursProps } from "@desktop/components/cron/types";
 
 export function Hours(props: HoursProps) {
   const {

--- a/apps/desktop/src/components/cron/fields/minutes.tsx
+++ b/apps/desktop/src/components/cron/fields/minutes.tsx
@@ -2,10 +2,10 @@
 // Original copyright (c) 2021 Xavier Rutayisire
 // https://github.com/xrutayisire/react-js-cron
 
+import { UNITS } from "@desktop/components/cron/constants";
 import { CustomSelect } from "@desktop/components/cron/fields/select";
-import { UNITS } from "../constants";
-import { DEFAULT_LOCALE_EN } from "../locale";
-import { MinutesProps } from "../types";
+import { DEFAULT_LOCALE_EN } from "@desktop/components/cron/locale";
+import { MinutesProps } from "@desktop/components/cron/types";
 
 export function Minutes(props: MinutesProps) {
   const {

--- a/apps/desktop/src/components/cron/fields/month-days.tsx
+++ b/apps/desktop/src/components/cron/fields/month-days.tsx
@@ -4,10 +4,10 @@
 
 import { useMemo } from "react";
 
+import { UNITS } from "@desktop/components/cron/constants";
 import { CustomSelect } from "@desktop/components/cron/fields/select";
-import { UNITS } from "../constants";
-import { DEFAULT_LOCALE_EN } from "../locale";
-import { MonthDaysProps } from "../types";
+import { DEFAULT_LOCALE_EN } from "@desktop/components/cron/locale";
+import { MonthDaysProps } from "@desktop/components/cron/types";
 
 export function MonthDays(props: MonthDaysProps) {
   const {

--- a/apps/desktop/src/components/cron/fields/months.tsx
+++ b/apps/desktop/src/components/cron/fields/months.tsx
@@ -2,10 +2,10 @@
 // Original copyright (c) 2021 Xavier Rutayisire
 // https://github.com/xrutayisire/react-js-cron
 
+import { UNITS } from "@desktop/components/cron/constants";
 import { CustomSelect } from "@desktop/components/cron/fields/select";
-import { UNITS } from "../constants";
-import { DEFAULT_LOCALE_EN } from "../locale";
-import { MonthsProps } from "../types";
+import { DEFAULT_LOCALE_EN } from "@desktop/components/cron/locale";
+import { MonthsProps } from "@desktop/components/cron/types";
 
 export function Months(props: MonthsProps) {
   const {

--- a/apps/desktop/src/components/cron/fields/period.tsx
+++ b/apps/desktop/src/components/cron/fields/period.tsx
@@ -12,8 +12,8 @@ import {
 import { useCallback } from "react";
 
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
-import { DEFAULT_LOCALE_EN } from "../locale";
-import { PeriodProps, PeriodType } from "../types";
+import { DEFAULT_LOCALE_EN } from "@desktop/components/cron/locale";
+import { PeriodProps, PeriodType } from "@desktop/components/cron/types";
 
 export function Period(props: PeriodProps) {
   const {

--- a/apps/desktop/src/components/cron/fields/select.tsx
+++ b/apps/desktop/src/components/cron/fields/select.tsx
@@ -9,9 +9,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@blinkdisk/ui/select";
+import { formatValue } from "@desktop/components/cron/converter";
+import { CustomSelectProps } from "@desktop/components/cron/types";
 import { useCallback, useMemo } from "react";
-import { formatValue } from "../converter";
-import { CustomSelectProps } from "../types";
 
 export function CustomSelect(props: CustomSelectProps) {
   const {

--- a/apps/desktop/src/components/cron/fields/week-days.tsx
+++ b/apps/desktop/src/components/cron/fields/week-days.tsx
@@ -4,10 +4,10 @@
 
 import { useMemo } from "react";
 
+import { UNITS } from "@desktop/components/cron/constants";
 import { CustomSelect } from "@desktop/components/cron/fields/select";
-import { UNITS } from "../constants";
-import { DEFAULT_LOCALE_EN } from "../locale";
-import { WeekDaysProps } from "../types";
+import { DEFAULT_LOCALE_EN } from "@desktop/components/cron/locale";
+import { WeekDaysProps } from "@desktop/components/cron/types";
 
 export function WeekDays(props: WeekDaysProps) {
   const {

--- a/apps/desktop/src/components/cron/index.tsx
+++ b/apps/desktop/src/components/cron/index.tsx
@@ -14,9 +14,9 @@ import { MonthDays } from "@desktop/components/cron/fields/month-days";
 import { Months } from "@desktop/components/cron/fields/months";
 import { Period } from "@desktop/components/cron/fields/period";
 import { WeekDays } from "@desktop/components/cron/fields/week-days";
+import { CronProps, Locale, PeriodType } from "@desktop/components/cron/types";
+import { usePrevious } from "@desktop/components/cron/utils";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { CronProps, Locale, PeriodType } from "./types";
-import { usePrevious } from "./utils";
 
 export function Cron(props: CronProps) {
   const { t } = useAppTranslation("cron");

--- a/apps/desktop/src/components/cron/locale.ts
+++ b/apps/desktop/src/components/cron/locale.ts
@@ -2,7 +2,7 @@
 // Original copyright (c) 2021 Xavier Rutayisire
 // https://github.com/xrutayisire/react-js-cron
 
-import { DefaultLocale } from "./types";
+import { DefaultLocale } from "@desktop/components/cron/types";
 
 export const DEFAULT_LOCALE_EN: DefaultLocale = {
   everyText: "every",

--- a/apps/desktop/src/components/cron/utils.ts
+++ b/apps/desktop/src/components/cron/utils.ts
@@ -4,8 +4,8 @@
 
 import { useEffect, useRef } from "react";
 
-import { DEFAULT_LOCALE_EN } from "./locale";
-import { Locale, OnError } from "./types";
+import { DEFAULT_LOCALE_EN } from "@desktop/components/cron/locale";
+import { Locale, OnError } from "@desktop/components/cron/types";
 
 /**
  * Creates an array of integers from start to end, inclusive

--- a/apps/desktop/src/components/dialogs/move-vaults/index.tsx
+++ b/apps/desktop/src/components/dialogs/move-vaults/index.tsx
@@ -1,3 +1,4 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
 import { Button } from "@blinkdisk/ui/button";
 import { Checkbox } from "@blinkdisk/ui/checkbox";
@@ -18,7 +19,6 @@ import { useSelectAccountDialog } from "@desktop/hooks/state/use-select-account-
 import { useReactivity } from "@desktop/hooks/use-reactivity";
 import { getVaultCollection } from "@desktop/lib/db";
 import { useNavigate } from "@tanstack/react-router";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
 import { ArrowUpDownIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 

--- a/apps/desktop/src/components/dialogs/select-account/index.tsx
+++ b/apps/desktop/src/components/dialogs/select-account/index.tsx
@@ -1,3 +1,4 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
 import { Button } from "@blinkdisk/ui/button";
 import {
@@ -13,7 +14,6 @@ import { RadioGroup, RadioGroupItem } from "@blinkdisk/ui/radio-group";
 import { AccountPreview } from "@desktop/components/accounts/preview";
 import { useAccountList } from "@desktop/hooks/queries/use-account-list";
 import { useSelectAccountDialog } from "@desktop/hooks/state/use-select-account-dialog";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
 import { useCallback, useState } from "react";
 
 export function SelectAccountDialog() {

--- a/apps/desktop/src/components/sidebar/index.tsx
+++ b/apps/desktop/src/components/sidebar/index.tsx
@@ -15,6 +15,7 @@ import { AccountSelectDropdown } from "@desktop/components/accounts/select-dropd
 import { SidebarAddFolder } from "@desktop/components/sidebar/add-folder";
 import { SidebarSelects } from "@desktop/components/sidebar/dropdowns";
 import { SidebarFolderList } from "@desktop/components/sidebar/folder-list";
+import { SidebarOfflineAlert } from "@desktop/components/sidebar/offline-alert";
 import { SidebarSkeletonTheme } from "@desktop/components/sidebar/skeleton-theme";
 import { SidebarStorageAlert } from "@desktop/components/sidebar/storage-alert";
 import { useFolderList } from "@desktop/hooks/queries/core/use-folder-list";
@@ -24,7 +25,6 @@ import { useOffline } from "@desktop/hooks/use-offline";
 import { Link, useLocation, useParams } from "@tanstack/react-router";
 import { EllipsisVerticalIcon, HomeIcon, SettingsIcon } from "lucide-react";
 import { ComponentProps } from "react";
-import { SidebarOfflineAlert } from "./offline-alert";
 
 export function Sidebar({ ...props }: ComponentProps<typeof SidebarContainer>) {
   const { isLocalAccount } = useAccountId();

--- a/apps/desktop/src/components/vaults/setup.tsx
+++ b/apps/desktop/src/components/vaults/setup.tsx
@@ -1,11 +1,11 @@
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
 import { ProviderConfig } from "@blinkdisk/schemas/providers";
+import { providerForms } from "@desktop/components/forms/providers";
 import { useSetupPasswordForm } from "@desktop/hooks/forms/use-setup-password-form";
 import { useSetupVault } from "@desktop/hooks/mutations/use-setup-vault";
 import { useVault } from "@desktop/hooks/queries/use-vault";
 import { SettingsIcon } from "lucide-react";
 import { useMemo, useState } from "react";
-import { providerForms } from "../forms/providers";
 
 export type SetupStep = "PASSWORD" | "CONFIG";
 

--- a/apps/desktop/src/hooks/forms/use-setup-password-form.ts
+++ b/apps/desktop/src/hooks/forms/use-setup-password-form.ts
@@ -3,7 +3,7 @@ import {
   ZVaultPasswordForm,
   ZVaultPasswordFormType,
 } from "@blinkdisk/schemas/vault";
-import { useVaultPassword } from "../queries/use-vault-password";
+import { useVaultPassword } from "@desktop/hooks/queries/use-vault-password";
 
 export function useSetupPasswordForm({
   vaultId,

--- a/apps/desktop/src/hooks/mutations/use-move-vaults.ts
+++ b/apps/desktop/src/hooks/mutations/use-move-vaults.ts
@@ -1,7 +1,7 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { showErrorToast } from "@blinkdisk/utils/error-toast";
 import { getConfigCollection, getVaultCollection } from "@desktop/lib/db";
 import { useMutation } from "@tanstack/react-query";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
 
 type MoveVaultsInput = {
   vaultIds: string[];

--- a/apps/desktop/src/hooks/mutations/use-setup-vault.ts
+++ b/apps/desktop/src/hooks/mutations/use-setup-vault.ts
@@ -1,3 +1,4 @@
+import { STORAGE_PROVIDERS } from "@blinkdisk/constants/providers";
 import { ProviderConfig } from "@blinkdisk/schemas/providers";
 import { CustomError } from "@blinkdisk/utils/error";
 import { showErrorToast } from "@blinkdisk/utils/error-toast";
@@ -11,7 +12,6 @@ import { useQueryKey } from "@desktop/hooks/use-query-key";
 import { getConfigCollection } from "@desktop/lib/db";
 import { trpc } from "@desktop/lib/trpc";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { STORAGE_PROVIDERS } from "libs/constants/src/providers";
 
 export function useSetupVault({
   onSuccess,

--- a/apps/desktop/src/hooks/mutations/use-update-account.ts
+++ b/apps/desktop/src/hooks/mutations/use-update-account.ts
@@ -1,9 +1,9 @@
 import { ZUpdateAccountType } from "@blinkdisk/schemas/accounts";
 import { CustomError } from "@blinkdisk/utils/error";
 import { showErrorToast } from "@blinkdisk/utils/error-toast";
+import { useAccountId } from "@desktop/hooks/use-account-id";
 import { useQueryKey } from "@desktop/hooks/use-query-key";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAccountId } from "../use-account-id";
 
 export function useUpdateAccount(onSuccess: () => void) {
   const queryClient = useQueryClient();

--- a/apps/desktop/src/hooks/mutations/use-update-preferences.ts
+++ b/apps/desktop/src/hooks/mutations/use-update-preferences.ts
@@ -1,10 +1,10 @@
 import { ZUpdatePreferencesType } from "@blinkdisk/schemas/settings";
 import { showErrorToast } from "@blinkdisk/utils/error-toast";
+import { useAccountId } from "@desktop/hooks/use-account-id";
 import { useQueryKey } from "@desktop/hooks/use-query-key";
 import { useTheme } from "@desktop/hooks/use-theme";
 import { i18n } from "@desktop/i18n";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAccountId } from "../use-account-id";
 
 export function useUpdatePreferences(onSuccess: () => void) {
   const queryClient = useQueryClient();

--- a/apps/desktop/src/hooks/queries/use-account-list.ts
+++ b/apps/desktop/src/hooks/queries/use-account-list.ts
@@ -1,7 +1,7 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { AccountStorageType } from "@blinkdisk/electron/store";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
+import { useAppStorage } from "@desktop/hooks/use-app-storage";
 import { useMemo } from "react";
-import { useAppStorage } from "../use-app-storage";
 
 export function useAccountList() {
   // @ts-expect-error Accounts not typed here

--- a/apps/desktop/src/hooks/queries/use-config-list.ts
+++ b/apps/desktop/src/hooks/queries/use-config-list.ts
@@ -1,5 +1,5 @@
+import { useAccountReactivity } from "@desktop/hooks/use-reactivity";
 import { getConfigCollection } from "@desktop/lib/db";
-import { useAccountReactivity } from "../use-reactivity";
 
 export function useConfigList() {
   const data = useAccountReactivity((accountId) =>

--- a/apps/desktop/src/hooks/queries/use-subscription.ts
+++ b/apps/desktop/src/hooks/queries/use-subscription.ts
@@ -1,7 +1,7 @@
+import { useAccountId } from "@desktop/hooks/use-account-id";
 import { useQueryKey } from "@desktop/hooks/use-query-key";
 import { trpc } from "@desktop/lib/trpc";
 import { useQuery } from "@tanstack/react-query";
-import { useAccountId } from "../use-account-id";
 
 type UseSubscriptionOptions = {
   refetchInterval?: number;

--- a/apps/desktop/src/hooks/queries/use-vault-list.ts
+++ b/apps/desktop/src/hooks/queries/use-vault-list.ts
@@ -1,5 +1,5 @@
+import { useAccountReactivity } from "@desktop/hooks/use-reactivity";
 import { getVaultCollection } from "@desktop/lib/db";
-import { useAccountReactivity } from "../use-reactivity";
 
 export function useVaultList() {
   const data = useAccountReactivity((accountId) =>

--- a/apps/desktop/src/hooks/use-account-id.ts
+++ b/apps/desktop/src/hooks/use-account-id.ts
@@ -1,5 +1,5 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { useParams } from "@tanstack/react-router";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
 import { useMemo } from "react";
 
 export function useAccountId() {

--- a/apps/desktop/src/hooks/use-auth.ts
+++ b/apps/desktop/src/hooks/use-auth.ts
@@ -1,13 +1,13 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
+import { useAccountList } from "@desktop/hooks/queries/use-account-list";
 import { useAuthDialog } from "@desktop/hooks/state/use-auth-dialog";
+import { useAccountId } from "@desktop/hooks/use-account-id";
 import { useAppStorage } from "@desktop/hooks/use-app-storage";
 import { useQueryKey } from "@desktop/hooks/use-query-key";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
 import { usePostHog } from "posthog-js/react";
 import { useCallback } from "react";
-import { useAccountList } from "./queries/use-account-list";
-import { useAccountId } from "./use-account-id";
 
 export function useAuth() {
   const navigate = useNavigate();

--- a/apps/desktop/src/hooks/use-local-profile.ts
+++ b/apps/desktop/src/hooks/use-local-profile.ts
@@ -1,6 +1,6 @@
+import { useProfile } from "@desktop/hooks/use-profile";
+import { useVaultId } from "@desktop/hooks/use-vault-id";
 import { useMemo } from "react";
-import { useProfile } from "./use-profile";
-import { useVaultId } from "./use-vault-id";
 
 export function useLocalProfile() {
   const { vaultId } = useVaultId();

--- a/apps/desktop/src/hooks/use-logsnag.ts
+++ b/apps/desktop/src/hooks/use-logsnag.ts
@@ -1,5 +1,5 @@
+import { useAccount } from "@desktop/hooks/queries/use-account";
 import { useCallback } from "react";
-import { useAccount } from "./queries/use-account";
 
 type LogsnagOptions = {
   channel: string;

--- a/apps/desktop/src/hooks/use-query-key.ts
+++ b/apps/desktop/src/hooks/use-query-key.ts
@@ -1,6 +1,6 @@
 import { useAccountId } from "@desktop/hooks/use-account-id";
+import { ProfileFilter } from "@desktop/hooks/use-profile";
 import { useMemo } from "react";
-import { ProfileFilter } from "./use-profile";
 
 export function useQueryKey() {
   const { accountId } = useAccountId();

--- a/apps/desktop/src/hooks/use-sync-listener.ts
+++ b/apps/desktop/src/hooks/use-sync-listener.ts
@@ -1,5 +1,5 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { useAccountId } from "@desktop/hooks/use-account-id";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
 import { useEffect } from "react";
 
 export function useSyncListener() {

--- a/apps/desktop/src/lib/bandwith.test.ts
+++ b/apps/desktop/src/lib/bandwith.test.ts
@@ -1,4 +1,4 @@
-import { fromBits, toBits } from "./bandwith";
+import { fromBits, toBits } from "@desktop/lib/bandwith";
 
 describe("fromBits", () => {
   it("returns bps for values under 1000", () => {

--- a/apps/desktop/src/lib/db.ts
+++ b/apps/desktop/src/lib/db.ts
@@ -1,9 +1,9 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { SchemaCollection } from "@blinkdisk/electron/db/schema";
 import { ZConfig, ZConfigType } from "@blinkdisk/schemas/config";
 import { ZVault, ZVaultType } from "@blinkdisk/schemas/vault";
 import { createElectronAdapter } from "@blinkdisk/signaldb-electron/renderer";
 import maverickReactivityAdapter from "@signaldb/maverickjs";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
 
 const vaultCollections: Record<
   string,

--- a/apps/desktop/src/lib/exclusion.test.ts
+++ b/apps/desktop/src/lib/exclusion.test.ts
@@ -1,4 +1,4 @@
-import { buildExclusionRule, parseExclusionRule } from "./exclusion";
+import { buildExclusionRule, parseExclusionRule } from "@desktop/lib/exclusion";
 
 describe("parseExclusionRule", () => {
   describe("extension patterns", () => {

--- a/apps/desktop/src/lib/filesize.test.ts
+++ b/apps/desktop/src/lib/filesize.test.ts
@@ -1,4 +1,4 @@
-import { fromBytes, toBytes } from "./filesize";
+import { fromBytes, toBytes } from "@desktop/lib/filesize";
 
 describe("fromBytes", () => {
   it("returns bytes for values under 1000", () => {

--- a/apps/desktop/src/lib/policy.test.ts
+++ b/apps/desktop/src/lib/policy.test.ts
@@ -6,7 +6,7 @@ import {
   emptyPolicy,
   getDefinedFields,
   pickDefinedFields,
-} from "./policy";
+} from "@desktop/lib/policy";
 
 describe("pickDefinedFields", () => {
   it("picks only the listed keys", () => {

--- a/apps/desktop/src/lib/throttle.test.ts
+++ b/apps/desktop/src/lib/throttle.test.ts
@@ -1,4 +1,7 @@
-import { convertThrottleFromCore, convertThrottleToCore } from "./throttle";
+import {
+  convertThrottleFromCore,
+  convertThrottleToCore,
+} from "@desktop/lib/throttle";
 
 describe("convertThrottleFromCore", () => {
   it("returns null for falsy input", () => {

--- a/apps/desktop/src/lib/trpc.ts
+++ b/apps/desktop/src/lib/trpc.ts
@@ -1,7 +1,7 @@
 import type { AppRouter } from "@blinkdisk/api/router";
 import { PROTOCOL_API_URL } from "@blinkdisk/constants/app";
+import { ACCOUNT_ID_HEADER } from "@blinkdisk/constants/header";
 import { createTRPCProxyClient, httpBatchLink } from "@trpc/client";
-import { ACCOUNT_ID_HEADER } from "libs/constants/src/header";
 
 export const trpc = createTRPCProxyClient<AppRouter>({
   links: [

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -16,7 +16,7 @@ import ReactDOM from "react-dom/client";
 
 import { DefaultErrorPage } from "@blinkdisk/components/errors/default";
 import { NotFoundPage } from "@blinkdisk/components/errors/not-found";
-import { routeTree } from "./routeTree.gen";
+import { routeTree } from "@desktop/routeTree.gen";
 
 export const history = createHashHistory();
 

--- a/apps/electron/src/auth.ts
+++ b/apps/electron/src/auth.ts
@@ -8,6 +8,11 @@ import { ZUpdateAccountType } from "@blinkdisk/schemas/accounts";
 import { ZUpdatePreferencesType } from "@blinkdisk/schemas/settings";
 import { tryCatch } from "@blinkdisk/utils/try-catch";
 import { initAccountCollections } from "@electron/db";
+import {
+  decryptString,
+  EncryptedString,
+  encryptString,
+} from "@electron/encryption";
 import { AccountStorageType, store } from "@electron/store";
 import { sendWindow } from "@electron/window";
 import {
@@ -16,7 +21,6 @@ import {
 } from "better-auth/client/plugins";
 import { createAuthClient, SuccessContext } from "better-auth/react";
 import { parseSetCookie } from "set-cookie-parser";
-import { decryptString, EncryptedString, encryptString } from "./encryption";
 
 export const authClient = createAuthClient({
   baseURL: process.env.API_URL,

--- a/apps/electron/src/db/index.ts
+++ b/apps/electron/src/db/index.ts
@@ -1,17 +1,17 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { ZConfig, ZConfigType } from "@blinkdisk/schemas/config";
 import { ZVault, ZVaultType } from "@blinkdisk/schemas/vault";
 import { setupSignalDBMain } from "@blinkdisk/signaldb-electron/main";
 import { getAccountCache } from "@electron/cache";
 import { SchemaCollection } from "@electron/db/schema";
+import { getLastSync, syncManager } from "@electron/db/sync";
 import { log } from "@electron/log";
 import { globalAccountDirectory } from "@electron/path";
 import { initVaults } from "@electron/vault/manage";
 import createFilesystemAdapter from "@signaldb/fs";
 import { ipcMain } from "electron";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
 import { existsSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
-import { getLastSync, syncManager } from "./sync";
 
 const bridge = setupSignalDBMain(ipcMain);
 

--- a/apps/electron/src/encryption.test.ts
+++ b/apps/electron/src/encryption.test.ts
@@ -1,4 +1,4 @@
-import { decryptVaultConfig, encryptVaultConfig } from "./encryption";
+import { decryptVaultConfig, encryptVaultConfig } from "@electron/encryption";
 
 describe("encryptVaultConfig / decryptVaultConfig", () => {
   it("roundtrips a simple object", async () => {

--- a/apps/electron/src/migration.ts
+++ b/apps/electron/src/migration.ts
@@ -1,9 +1,9 @@
+import { storeToken } from "@electron/auth";
+import { log } from "@electron/log";
 import { store } from "@electron/store";
 import { captureException } from "@sentry/electron/main";
 import { SessionResponse } from "better-auth/client";
 import { safeStorage, session } from "electron";
-import { storeToken } from "./auth";
-import { log } from "./log";
 
 export async function runMigrations() {
   try {

--- a/apps/electron/src/profile.ts
+++ b/apps/electron/src/profile.ts
@@ -1,7 +1,7 @@
+import { globalVaultDirectory } from "@electron/path";
 import { existsSync, readFileSync } from "node:fs";
 import { hostname, userInfo } from "node:os";
 import { resolve } from "node:path";
-import { globalVaultDirectory } from "./path";
 
 export function getUserName(vaultId: string) {
   try {

--- a/apps/electron/src/protocol.ts
+++ b/apps/electron/src/protocol.ts
@@ -4,11 +4,11 @@ import {
   PROTOCOL_FRONTEND_NS,
   PROTOCOL_VAULT_NS,
 } from "@blinkdisk/constants/app";
+import { ACCOUNT_ID_HEADER } from "@blinkdisk/constants/header";
 import { getAccountCookie } from "@electron/auth";
 import { fetchVaultRaw } from "@electron/vault/fetch";
 import { getVault } from "@electron/vault/manage";
 import { app, net, protocol } from "electron";
-import { ACCOUNT_ID_HEADER } from "libs/constants/src/header";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 

--- a/apps/electron/src/store.ts
+++ b/apps/electron/src/store.ts
@@ -1,9 +1,9 @@
 import { EncryptedString } from "@electron/encryption";
+import { globalConfigDirectory } from "@electron/path";
 import { initVaults } from "@electron/vault/manage";
 import { sendWindow } from "@electron/window";
 import { app } from "electron";
 import Store from "electron-store";
-import { globalConfigDirectory } from "./path";
 
 export type GlobalStorageType = {
   authenticated: boolean;

--- a/apps/electron/src/trpc.ts
+++ b/apps/electron/src/trpc.ts
@@ -1,6 +1,6 @@
 import type { AppRouter } from "@blinkdisk/api/router";
+import { authClient, getAccountCookie } from "@electron/auth";
 import { createTRPCProxyClient, httpLink } from "@trpc/client";
-import { authClient, getAccountCookie } from "./auth";
 
 export const trpc = createTRPCProxyClient<AppRouter>({
   links: [

--- a/apps/electron/src/vault/fetch.ts
+++ b/apps/electron/src/vault/fetch.ts
@@ -1,8 +1,8 @@
+import { VaultInstance } from "@electron/vault/types";
 import { createWriteStream } from "fs";
 import { rename } from "fs/promises";
 import https from "https";
 import { Cookie } from "tough-cookie";
-import { VaultInstance } from "./types";
 
 export async function fetchVault(
   vault: VaultInstance,

--- a/apps/electron/src/vault/manage.ts
+++ b/apps/electron/src/vault/manage.ts
@@ -1,3 +1,4 @@
+import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { StorageProviderType } from "@blinkdisk/constants/providers";
 import { LATEST_VAULT_VERSION } from "@blinkdisk/constants/vault";
 import { ProviderConfig } from "@blinkdisk/schemas/providers";
@@ -9,9 +10,8 @@ import { getHostName, getUserName } from "@electron/profile";
 import { fetchVault } from "@electron/vault/fetch";
 import { mapConfigFields, mapProviderType } from "@electron/vault/mapping";
 import { startVaultServer } from "@electron/vault/server";
-import { LOCAL_ACCOUNT_ID } from "libs/constants/src/account";
-import { VaultInstance } from "./types";
-import { validationVault } from "./validate";
+import { VaultInstance } from "@electron/vault/types";
+import { validationVault } from "@electron/vault/validate";
 
 export const vaults: Record<string, VaultInstance> = {};
 

--- a/apps/electron/src/vault/mapping.test.ts
+++ b/apps/electron/src/vault/mapping.test.ts
@@ -1,4 +1,4 @@
-import { mapConfigFields, mapProviderType } from "./mapping";
+import { mapConfigFields, mapProviderType } from "@electron/vault/mapping";
 
 describe("mapProviderType", () => {
   it("maps standard provider types to core types", () => {

--- a/apps/electron/src/vault/server.ts
+++ b/apps/electron/src/vault/server.ts
@@ -2,6 +2,7 @@ import { generateId } from "@blinkdisk/utils/id";
 import { tryCatch } from "@blinkdisk/utils/try-catch";
 import { log } from "@electron/log";
 import { corePath, globalVaultDirectory } from "@electron/path";
+import { fetchVault } from "@electron/vault/fetch";
 import { vaults } from "@electron/vault/manage";
 import { VaultServer, VaultStatus } from "@electron/vault/types";
 import { sendWindow } from "@electron/window";
@@ -10,7 +11,6 @@ import { app } from "electron";
 import { existsSync, renameSync } from "fs";
 import { resolve } from "path";
 import { CookieJar } from "tough-cookie";
-import { fetchVault } from "./fetch";
 
 export function startVaultServer(id: string, pollStatus = true) {
   return new Promise<VaultServer>((res) => {

--- a/apps/marketing/src/components/compare/ComparisonRow.astro
+++ b/apps/marketing/src/components/compare/ComparisonRow.astro
@@ -1,6 +1,6 @@
 ---
 import type { CellValue } from "@blinkdisk/constants/comparison";
-import ComparisonCell from "./ComparisonCell.astro";
+import ComparisonCell from "@marketing/components/compare/ComparisonCell.astro";
 import WindowsIcon from "@marketing/components/icons/Windows.astro";
 import MacosIcon from "@marketing/components/icons/Macos.astro";
 import LinuxIcon from "@marketing/components/icons/Linux.astro";

--- a/apps/marketing/src/components/compare/ComparisonTable.astro
+++ b/apps/marketing/src/components/compare/ComparisonTable.astro
@@ -4,7 +4,7 @@ import type {
   CellValue,
   LabelConfig,
 } from "@blinkdisk/constants/comparison";
-import ComparisonRow from "./ComparisonRow.astro";
+import ComparisonRow from "@marketing/components/compare/ComparisonRow.astro";
 
 type Props = {
   tools: (BackupTool | null)[];

--- a/apps/marketing/src/components/compare/react/PricingCalculator.tsx
+++ b/apps/marketing/src/components/compare/react/PricingCalculator.tsx
@@ -1,11 +1,11 @@
 import type { BackupTool } from "@blinkdisk/constants/comparison";
-import AcronisPricingCalculator from "./AcronisPricingCalculator";
-import BackblazePricingCalculator from "./BackblazePricingCalculator";
-import BlinkDiskPricingCalculator from "./BlinkDiskPricingCalculator";
-import CarbonitePricingCalculator from "./CarbonitePricingCalculator";
-import CrashPlanPricingCalculator from "./CrashPlanPricingCalculator";
-import EaseUSTodoBackupPricingCalculator from "./EaseUSTodoBackupPricingCalculator";
-import IDrivePricingCalculator from "./IDrivePricingCalculator";
+import AcronisPricingCalculator from "@marketing/components/compare/react/AcronisPricingCalculator";
+import BackblazePricingCalculator from "@marketing/components/compare/react/BackblazePricingCalculator";
+import BlinkDiskPricingCalculator from "@marketing/components/compare/react/BlinkDiskPricingCalculator";
+import CarbonitePricingCalculator from "@marketing/components/compare/react/CarbonitePricingCalculator";
+import CrashPlanPricingCalculator from "@marketing/components/compare/react/CrashPlanPricingCalculator";
+import EaseUSTodoBackupPricingCalculator from "@marketing/components/compare/react/EaseUSTodoBackupPricingCalculator";
+import IDrivePricingCalculator from "@marketing/components/compare/react/IDrivePricingCalculator";
 
 type Props = {
   tool: BackupTool;

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,7 +11,7 @@ import ReactDOM from "react-dom/client";
 
 import { DefaultErrorPage } from "@blinkdisk/components/errors/default";
 import { NotFoundPage } from "@blinkdisk/components/errors/not-found";
-import { routeTree } from "./routeTree.gen";
+import { routeTree } from "@web/routeTree.gen";
 
 const router = createRouter({
   routeTree,

--- a/libs/db/src/index.ts
+++ b/libs/db/src/index.ts
@@ -1,8 +1,8 @@
 import { Kysely, PostgresDialect } from "kysely";
 import { jsonArrayFrom } from "kysely/helpers/postgres";
 
+import { DB as Schema } from "@db/schema";
 import { Pool } from "pg";
-import { DB as Schema } from "./schema";
 
 export const dialect = (databaseUrl: string) =>
   new PostgresDialect({

--- a/libs/db/src/schema.ts
+++ b/libs/db/src/schema.ts
@@ -10,7 +10,7 @@ import type {
   SubscriptionStatus,
   VaultProvider,
   VaultStatus,
-} from "./enums";
+} from "@db/enums";
 
 export type Account = {
   id: Generated<string>;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactor to replace relative imports with workspace aliases across apps and libs, improving consistency and path stability.

- **Refactors**
  - Adopted aliases across the repo: `@desktop/*`, `@electron/*`, `@marketing/*`, `@web/*`, `@db/*`, `@api/*`; centralized constants under `@blinkdisk/constants/*`.
  - Desktop Cron: moved types, utils, and fields to `@desktop/components/cron/*` and updated all consumers.
  - Electron: switched auth, db/sync, encryption, path, and vault modules to `@electron/*`; updated protocol/TRPC to use shared headers and auth client.
  - API: updated affiliate import to `@api/lib/*`.
  - Updated route tree imports to `@desktop/routeTree.gen` and `@web/routeTree.gen`, and fixed tests to use absolute paths.

<sup>Written for commit aa5fb8412aea3bbf3deeb79dfaa9890d0e5d4f8b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

