### PR TITLE
build: always deploy desktop first

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,13 +1,15 @@
 name: Deploy API
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_run:
+    workflows: ["Deploy Desktop"]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-cloud.yml
+++ b/.github/workflows/deploy-cloud.yml
@@ -1,13 +1,15 @@
 name: Deploy Cloud
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_run:
+    workflows: ["Deploy Desktop"]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -1,13 +1,15 @@
 name: Deploy Marketing
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_run:
+    workflows: ["Deploy Desktop"]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,13 +1,15 @@
 name: Deploy Web
 
 on:
-  push:
-    tags:
-      - v*
+  workflow_run:
+    workflows: ["Deploy Desktop"]
+    types:
+      - completed
   workflow_dispatch:
 
 jobs:
   deploy:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure all non-desktop deploys run only after `Deploy Desktop` completes successfully. Manual dispatch remains available for each workflow.

- **Refactors**
  - Switched `deploy-api.yml`, `deploy-cloud.yml`, `deploy-marketing.yml`, and `deploy-web.yml` from tag-based `push` to `workflow_run` on `Deploy Desktop` (type: `completed`).
  - Added job guard to run only on `workflow_dispatch` or when the upstream `workflow_run.conclusion` is `success`.

<sup>Written for commit 571d781174732804fae86ed41e686caad129db12. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

