### PR TITLE
refactor(desktop): use popover colors in tooltip

### DIFF
--- a/apps/desktop/src/components/vaults/remote-tooltip.tsx
+++ b/apps/desktop/src/components/vaults/remote-tooltip.tsx
@@ -14,10 +14,10 @@ export function RemoteTooltip({ children }: RemoteTooltipProps) {
   if (!remote) return children;
   return (
     <Tooltip>
-      <TooltipContent className="max-w-55 rounded-lg p-4">
+      <TooltipContent className="max-w-55 flex-col items-start rounded-lg p-4">
         <div className="flex items-center gap-1">
           <LockIcon className="mr-1 size-4" />
-          <p className="font-medium">{t("title")}</p>
+          <p className="text-sm font-medium">{t("title")}</p>
         </div>
         <p className="text-muted-foreground mt-1 text-xs">{t("description")}</p>
       </TooltipContent>

--- a/libs/ui/src/tooltip.tsx
+++ b/libs/ui/src/tooltip.tsx
@@ -48,13 +48,12 @@ function TooltipContent({
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(
-            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 origin-(--transform-origin) bg-foreground text-background z-50 inline-flex w-fit max-w-xs items-center gap-1.5 rounded-md px-3 py-1.5 text-xs",
+            "data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 origin-(--transform-origin) border bg-popover text-popover-foreground shadow-md z-50 inline-flex w-fit max-w-xs items-center gap-1.5 rounded-md px-3 py-1.5 text-xs",
             className,
           )}
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="data-[side=inline-end]:top-1/2! data-[side=inline-start]:top-1/2! bg-foreground fill-foreground data-[side=left]:top-1/2! data-[side=right]:top-1/2! z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] data-[side=bottom]:top-1 data-[side=inline-end]:-left-1 data-[side=inline-start]:-right-1 data-[side=left]:-right-1 data-[side=right]:-left-1 data-[side=top]:-bottom-2.5 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:-translate-y-1/2 data-[side=right]:-translate-y-1/2" />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized tooltip styling to use popover colors for better contrast and consistency. Also simplified the UI by removing the arrow and tidied the desktop RemoteTooltip layout.

- **Refactors**
  - Tooltip now uses popover colors with a border and shadow; removed the arrow.
  - Remote tooltip stacks content vertically, left-aligns items, and sets the title to `text-sm` for clearer hierarchy.

<sup>Written for commit ed1751eab6cd09ccfbb4f0bc62c4788c498eb30a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

