### PR TITLE
fix: allow resubscribing in grace period

### DIFF
--- a/apps/api/src/routers/payment.ts
+++ b/apps/api/src/routers/payment.ts
@@ -28,6 +28,22 @@ export const paymentRouter = router({
       const price = plan.prices.find((p) => p.id === input.priceId);
       if (!price || !price.polarId) throw new CustomError("PRICE_NOT_FOUND");
 
+      const space = await ctx.db
+        .selectFrom("Space")
+        .select(["id"])
+        .where("accountId", "=", ctx.account.id)
+        .executeTakeFirst();
+
+      if (space) {
+        const stub = ctx.env.SPACE.getByName(space.id);
+        const used = await (
+          stub as unknown as { getUsed: () => Promise<number> }
+        ).getUsed();
+
+        const bytes = plan.storageGB * 1000 * 1000 * 1000;
+        if (used > bytes) throw new CustomError("NOT_ALLOWED");
+      }
+
       const account = await ctx.db
         .selectFrom("Account")
         .select(["polarId"])

--- a/apps/api/src/webhooks/polar.ts
+++ b/apps/api/src/webhooks/polar.ts
@@ -81,6 +81,14 @@ export async function polarWebhook(
 
         if (!account) return c.json({ error: "Account not found" }, 400);
 
+        // Clear cleanupAt on any previous subscriptions for this account
+        // to prevent stale cleanup emails and data deletion
+        await db
+          .updateTable("Subscription")
+          .set({ cleanupAt: null })
+          .where("accountId", "=", account.id)
+          .execute();
+
         accountId = account.id;
         subscriptionId = generateId("Subscription");
         planUpdated = true;

--- a/apps/cloud/src/classes/space.ts
+++ b/apps/cloud/src/classes/space.ts
@@ -56,11 +56,9 @@ export class Space extends DurableObject<Cloudflare.Env> {
     return (await this.ctx.storage.get<number>("usedBytes")) || 0;
   }
 
-  async updateCapacity(capacity: number, used?: number) {
+  async updateCapacity(capacity: number) {
     await this.ctx.storage.put("capacity", capacity);
     await this.ctx.storage.put("notifications", []);
-
-    if (used !== undefined) await this.ctx.storage.put("usedBytes", used);
   }
 
   async alarm() {

--- a/apps/cloud/src/classes/vault.ts
+++ b/apps/cloud/src/classes/vault.ts
@@ -167,7 +167,7 @@ export class Vault extends DurableObject<Cloudflare.Env> {
     this.sessions.delete(ws);
   }
 
-  async delete(vaultId: string, updateSpace: boolean) {
+  async delete(vaultId: string) {
     let marker: string | null = null;
     while (true) {
       const res = (await this.s3.send(
@@ -197,15 +197,13 @@ export class Vault extends DurableObject<Cloudflare.Env> {
       else break;
     }
 
-    if (updateSpace) {
-      const spaceId = await this.ctx.storage.get<string>("spaceId");
-      const currentBytes =
-        (await this.ctx.storage.get<number>("currentBytes")) || 0;
+    const spaceId = await this.ctx.storage.get<string>("spaceId");
+    const currentBytes =
+      (await this.ctx.storage.get<number>("currentBytes")) || 0;
 
-      if (spaceId && currentBytes) {
-        const stub = this.env.SPACE.getByName(spaceId);
-        await stub.subtract(currentBytes);
-      }
+    if (spaceId && currentBytes) {
+      const stub = this.env.SPACE.getByName(spaceId);
+      await stub.subtract(currentBytes);
     }
 
     // Delete this durable object itself

--- a/apps/cloud/src/utils/cleanup.ts
+++ b/apps/cloud/src/utils/cleanup.ts
@@ -67,12 +67,12 @@ export async function cleanup(
 
   for (const space of spaces) {
     const stub = env.SPACE.getByName(space.id);
-    await stub.updateCapacity(FREE_SPACE_AVAILABLE, 0);
+    await stub.updateCapacity(FREE_SPACE_AVAILABLE);
   }
 
   await db
     .updateTable("Space")
-    .set({ used: String(0), capacity: FREE_SPACE_AVAILABLE.toString() })
+    .set({ capacity: FREE_SPACE_AVAILABLE.toString() })
     .where(
       "id",
       "in",
@@ -92,6 +92,6 @@ export async function cleanup(
 
   for (const vault of vaults) {
     const stub = env.VAULT.getByName(vault.id);
-    await stub.delete(vault.id, false);
+    await stub.delete(vault.id);
   }
 }

--- a/apps/desktop/src/components/dialogs/upgrade/index.tsx
+++ b/apps/desktop/src/components/dialogs/upgrade/index.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
 } from "@blinkdisk/ui/dialog";
 import { Tabs, TabsList, TabsTrigger } from "@blinkdisk/ui/tabs";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@blinkdisk/ui/tooltip";
 import { Trans } from "@blinkdisk/utils/i18n";
 import { PendingCheckoutDialog } from "@desktop/components/dialogs/pending-checkout";
 import {
@@ -196,11 +197,11 @@ function Plan({
     return "UPGRADE";
   }, [plan, price, subscription]);
 
-  const isDowngradePossible = useMemo(() => {
-    if (action !== "DOWNGRADE" || !space) return true;
+  const hasInsufficientStorage = useMemo(() => {
+    if (!space) return false;
     const bytes = plan.storageGB * 1000 * 1000 * 1000;
-    return space.used < bytes;
-  }, [plan, action, space]);
+    return space.used >= bytes;
+  }, [plan, space]);
 
   if (!price) return null;
   return (
@@ -310,7 +311,7 @@ function Plan({
           </p>
         </div>
       )}
-      <div className="mt-2 [&>button]:w-full">
+      <div className="mt-2 [&_button]:w-full">
         {contact ? (
           <Button onClick={() => window.open("mailto:cloud@blinkdisk.com")}>
             {t("contact.button")}
@@ -324,35 +325,49 @@ function Plan({
             {t("manage")}
           </Button>
         ) : action === "UPGRADE" ? (
-          <Button
-            loading={isCheckoutPending}
-            onClick={() =>
-              subscription
-                ? setChange({ action: "UPGRADE", priceId: price.id })
-                : checkout({
-                    priceId: price.id,
-                  })
-            }
+          <InsufficientStorageTooltip
+            disabled={hasInsufficientStorage}
+            storageGB={plan.storageGB}
           >
-            {t("upgrade", {
-              storageGB: plan.storageGB.toLocaleString(),
-            })}
-          </Button>
+            <Button
+              loading={isCheckoutPending}
+              disabled={hasInsufficientStorage}
+              onClick={() =>
+                subscription
+                  ? setChange({ action: "UPGRADE", priceId: price.id })
+                  : checkout({
+                      priceId: price.id,
+                    })
+              }
+            >
+              {t("upgrade", {
+                storageGB: plan.storageGB.toLocaleString(),
+              })}
+            </Button>
+          </InsufficientStorageTooltip>
         ) : action === "DOWNGRADE" ? (
-          <Button
-            onClick={() => {
-              setChange({
-                action: "DOWNGRADE",
-                priceId: price.id,
-              });
-            }}
-            disabled={!isDowngradePossible}
-            variant="secondary"
+          <InsufficientStorageTooltip
+            disabled={hasInsufficientStorage}
+            storageGB={plan.storageGB}
           >
-            {t(isDowngradePossible ? "downgrade" : "downgradeNotPossible", {
-              storageGB: plan.storageGB.toLocaleString(),
-            })}
-          </Button>
+            <Button
+              onClick={() => {
+                setChange({
+                  action: "DOWNGRADE",
+                  priceId: price.id,
+                });
+              }}
+              disabled={hasInsufficientStorage}
+              variant="secondary"
+            >
+              {t(
+                hasInsufficientStorage ? "downgradeNotPossible" : "downgrade",
+                {
+                  storageGB: plan.storageGB.toLocaleString(),
+                },
+              )}
+            </Button>
+          </InsufficientStorageTooltip>
         ) : (
           <Button
             onClick={() => {
@@ -370,5 +385,31 @@ function Plan({
         )}
       </div>
     </div>
+  );
+}
+
+type InsufficientStorageTooltipProps = {
+  children: React.ReactNode;
+  disabled: boolean;
+  storageGB: number;
+};
+
+function InsufficientStorageTooltip({
+  children,
+  disabled,
+  storageGB,
+}: InsufficientStorageTooltipProps) {
+  const { t } = useAppTranslation("subscription.upgradeDialog.plan");
+
+  if (!disabled) return children;
+  return (
+    <Tooltip>
+      <TooltipContent>
+        {t("insufficientStorage", {
+          storageGB: storageGB.toLocaleString(),
+        })}
+      </TooltipContent>
+      <TooltipTrigger render={<span tabIndex={0} />}>{children}</TooltipTrigger>
+    </Tooltip>
   );
 }

--- a/locales/en/subscription.json
+++ b/locales/en/subscription.json
@@ -18,6 +18,7 @@
       "manage": "Manage subscription",
       "periodChange": "Switch to {{period}} plan",
       "downgradeNotPossible": "Downgrade not possible",
+      "insufficientStorage": "Your current usage exceeds {{storageGB}} GB. Free up storage to select this plan.",
       "period": {
         "monthly": "Monthly",
         "yearly": "Yearly"


### PR DESCRIPTION
Closes #28  

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows users in the grace period to resubscribe without triggering cleanup or losing usage data. Adds storage checks and clearer UI to prevent selecting a plan smaller than current usage.

- **Bug Fixes**
  - Clear `cleanupAt` on prior subscriptions in Polar webhook to stop stale cleanup after resubscribe.
  - Preserve `usedBytes` during capacity updates and grace-period cleanup; only update capacity.
  - Block checkout when current usage exceeds the selected plan (`NOT_ALLOWED` in `paymentRouter`).

- **New Features**
  - Disable upgrade/downgrade buttons when a plan is too small and show an “insufficient storage” tooltip in the desktop Upgrade dialog (new i18n copy).

<sup>Written for commit d7cdcb8195a4cf1b6811d7d212f814eeeaa26bfb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

