### PR TITLE
test: add more basic unit tests

### DIFF
--- a/apps/desktop/src/components/cron/converter.test.ts
+++ b/apps/desktop/src/components/cron/converter.test.ts
@@ -1,0 +1,172 @@
+import { UNITS } from "@desktop/components/cron/constants";
+import {
+  formatValue,
+  getCronStringFromValues,
+} from "@desktop/components/cron/converter";
+
+describe("getCronStringFromValues", () => {
+  it('period "minute" returns all wildcards', () => {
+    expect(
+      getCronStringFromValues(
+        "minute",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ),
+    ).toBe("* * * * *");
+  });
+
+  it('period "hour" with minutes produces correct cron', () => {
+    expect(
+      getCronStringFromValues(
+        "hour",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [0, 30],
+        undefined,
+        undefined,
+      ),
+    ).toBe("0,30 * * * *");
+  });
+
+  it('period "day" with hours and minutes produces correct cron', () => {
+    expect(
+      getCronStringFromValues(
+        "day",
+        undefined,
+        undefined,
+        undefined,
+        [9],
+        [0],
+        undefined,
+        undefined,
+      ),
+    ).toBe("0 9 * * *");
+  });
+
+  it('period "week" with weekDays, hours, and minutes produces correct cron', () => {
+    expect(
+      getCronStringFromValues(
+        "week",
+        undefined,
+        undefined,
+        [1, 2, 3, 4, 5],
+        [8],
+        [0],
+        undefined,
+        undefined,
+      ),
+    ).toBe("0 8 * * 1-5");
+  });
+
+  it('period "month" with monthDays, hours, and minutes produces correct cron', () => {
+    expect(
+      getCronStringFromValues(
+        "month",
+        undefined,
+        [1],
+        undefined,
+        [0],
+        [0],
+        undefined,
+        undefined,
+      ),
+    ).toBe("0 0 1 * *");
+  });
+
+  it('period "year" with all fields produces correct cron', () => {
+    expect(
+      getCronStringFromValues(
+        "year",
+        [1],
+        [1],
+        undefined,
+        [0],
+        [0],
+        undefined,
+        undefined,
+      ),
+    ).toBe("0 0 1 1 *");
+  });
+
+  it('period "reboot" returns @reboot', () => {
+    expect(
+      getCronStringFromValues(
+        "reboot",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ),
+    ).toBe("@reboot");
+  });
+
+  it("uses interval representation for evenly spaced minutes", () => {
+    expect(
+      getCronStringFromValues(
+        "hour",
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        [0, 15, 30, 45],
+        undefined,
+        undefined,
+      ),
+    ).toBe("*/15 * * * *");
+  });
+
+  it("uses range representation for consecutive hours", () => {
+    expect(
+      getCronStringFromValues(
+        "day",
+        undefined,
+        undefined,
+        undefined,
+        [9, 10, 11, 12, 13],
+        [0],
+        undefined,
+        undefined,
+      ),
+    ).toBe("0 9-13 * * *");
+  });
+});
+
+describe("formatValue", () => {
+  it("formats a basic number", () => {
+    expect(formatValue(5, UNITS[0]!)).toBe("5");
+  });
+
+  it("adds leading zero when enabled", () => {
+    expect(formatValue(5, UNITS[0]!, false, true)).toBe("05");
+  });
+
+  it("formats 12-hour clock PM", () => {
+    expect(formatValue(14, UNITS[1]!, false, false, "12-hour-clock")).toBe(
+      "2PM",
+    );
+  });
+
+  it("formats 12-hour clock AM", () => {
+    expect(formatValue(9, UNITS[1]!, false, false, "12-hour-clock")).toBe(
+      "9AM",
+    );
+  });
+
+  it("humanizes months", () => {
+    expect(formatValue(1, UNITS[3]!, true)).toBe("JAN");
+  });
+
+  it("humanizes weekdays", () => {
+    expect(formatValue(0, UNITS[4]!, true)).toBe("SUN");
+  });
+});

--- a/apps/desktop/src/components/cron/utils.test.ts
+++ b/apps/desktop/src/components/cron/utils.test.ts
@@ -1,0 +1,99 @@
+import { DEFAULT_LOCALE_EN } from "@desktop/components/cron/locale";
+import {
+  convertStringToNumber,
+  dedup,
+  range,
+  setError,
+  sort,
+} from "@desktop/components/cron/utils";
+
+describe("range", () => {
+  it("creates an inclusive range from start to end", () => {
+    expect(range(1, 5)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("returns a single-element array when start equals end", () => {
+    expect(range(0, 0)).toEqual([0]);
+  });
+
+  it("returns an empty array when start is greater than end", () => {
+    expect(range(5, 3)).toEqual([]);
+  });
+});
+
+describe("sort", () => {
+  it("sorts numbers ascending", () => {
+    expect(sort([3, 1, 4, 1, 5])).toEqual([1, 1, 3, 4, 5]);
+  });
+
+  it("handles empty array", () => {
+    expect(sort([])).toEqual([]);
+  });
+
+  it("handles already sorted array", () => {
+    expect(sort([1, 2, 3])).toEqual([1, 2, 3]);
+  });
+});
+
+describe("dedup", () => {
+  it("removes duplicates", () => {
+    expect(dedup([1, 1, 2, 3, 3])).toEqual([1, 2, 3]);
+  });
+
+  it("preserves order", () => {
+    expect(dedup([3, 1, 3, 2, 1])).toEqual([3, 1, 2]);
+  });
+
+  it("handles empty array", () => {
+    expect(dedup([])).toEqual([]);
+  });
+});
+
+describe("convertStringToNumber", () => {
+  it("converts valid integer strings", () => {
+    expect(convertStringToNumber("5")).toBe(5);
+    expect(convertStringToNumber("0")).toBe(0);
+  });
+
+  it("rejects float strings", () => {
+    expect(convertStringToNumber("1.5")).toBeNaN();
+  });
+
+  it("rejects hex strings", () => {
+    expect(convertStringToNumber("0x10")).toBeNaN();
+  });
+
+  it("rejects empty string", () => {
+    expect(convertStringToNumber("")).toBeNaN();
+  });
+
+  it("rejects non-numeric strings", () => {
+    expect(convertStringToNumber("abc")).toBeNaN();
+  });
+});
+
+describe("setError", () => {
+  it("calls onError with correct error object", () => {
+    const onError = vi.fn();
+    setError(onError, {});
+
+    expect(onError).toHaveBeenCalledWith({
+      type: "invalid_cron",
+      description: DEFAULT_LOCALE_EN.errorInvalidCron,
+    });
+  });
+
+  it("uses locale errorInvalidCron when provided", () => {
+    const onError = vi.fn();
+    setError(onError, { errorInvalidCron: "Custom error" });
+
+    expect(onError).toHaveBeenCalledWith({
+      type: "invalid_cron",
+      description: "Custom error",
+    });
+  });
+
+  it("does nothing when onError is undefined", () => {
+    expect(() => setError(undefined, {})).not.toThrow();
+  });
+});

--- a/apps/desktop/src/lib/backup.test.ts
+++ b/apps/desktop/src/lib/backup.test.ts
@@ -1,0 +1,40 @@
+import { formatBackupDate, getBackupDisplayName } from "@desktop/lib/backup";
+
+describe("getBackupDisplayName", () => {
+  it("returns description when present", () => {
+    const backup = {
+      description: "Weekly backup",
+      startTime: "2024-01-15T10:30:00Z",
+    };
+    expect(getBackupDisplayName(backup)).toBe("Weekly backup");
+  });
+
+  it("falls back to formatted date when description is empty string", () => {
+    const backup = { description: "", startTime: "2024-01-15T10:30:00Z" };
+    const result = getBackupDisplayName(backup);
+    expect(result).not.toBe("");
+    expect(result).toBe(formatBackupDate(backup));
+  });
+});
+
+describe("formatBackupDate", () => {
+  it("returns a non-empty string for valid ISO dates", () => {
+    expect(formatBackupDate({ startTime: "2024-01-15T10:30:00Z" })).toBeTruthy();
+    expect(typeof formatBackupDate({ startTime: "2024-01-15T10:30:00Z" })).toBe(
+      "string",
+    );
+  });
+
+  it("handles various date formats", () => {
+    const dates = [
+      "2024-01-01T00:00:00Z",
+      "2023-12-31T23:59:59Z",
+      "2024-06-15T12:00:00+05:00",
+    ];
+
+    for (const startTime of dates) {
+      const result = formatBackupDate({ startTime });
+      expect(result.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/apps/desktop/src/lib/folder.test.ts
+++ b/apps/desktop/src/lib/folder.test.ts
@@ -1,0 +1,53 @@
+import { hashFolder } from "@desktop/lib/folder";
+
+describe("hashFolder", () => {
+  it("returns a 40-character hex string", async () => {
+    const result = await hashFolder({
+      hostName: "myhost",
+      userName: "user",
+      path: "/home/user/docs",
+    });
+    expect(result).toHaveLength(40);
+  });
+
+  it("all characters are valid hex", async () => {
+    const result = await hashFolder({
+      hostName: "myhost",
+      userName: "user",
+      path: "/home/user/docs",
+    });
+    expect(result).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("same inputs produce the same hash (deterministic)", async () => {
+    const input = {
+      hostName: "myhost",
+      userName: "user",
+      path: "/home/user/docs",
+    };
+    const first = await hashFolder(input);
+    const second = await hashFolder(input);
+    expect(first).toBe(second);
+  });
+
+  it("different inputs produce different hashes", async () => {
+    const hash1 = await hashFolder({
+      hostName: "host1",
+      userName: "user",
+      path: "/path",
+    });
+    const hash2 = await hashFolder({
+      hostName: "host2",
+      userName: "user",
+      path: "/path",
+    });
+    const hash3 = await hashFolder({
+      hostName: "host1",
+      userName: "other",
+      path: "/path",
+    });
+    expect(hash1).not.toBe(hash2);
+    expect(hash1).not.toBe(hash3);
+    expect(hash2).not.toBe(hash3);
+  });
+});

--- a/apps/desktop/src/lib/number.test.ts
+++ b/apps/desktop/src/lib/number.test.ts
@@ -1,0 +1,35 @@
+import { formatInt, formatSize } from "@desktop/lib/number";
+
+describe("formatSize", () => {
+  it.each([0, 1000, 1_000_000, 1_000_000_000])(
+    "returns a string for size %i",
+    (size) => {
+      const result = formatSize(size);
+      expect(typeof result).toBe("string");
+      expect(String(result).length).toBeGreaterThan(0);
+    },
+  );
+
+  it("result contains expected unit indicators", () => {
+    expect(String(formatSize(0))).toContain("B");
+    expect(String(formatSize(1_000_000))).toContain("MB");
+    expect(String(formatSize(1_000_000_000))).toContain("GB");
+  });
+});
+
+describe("formatInt", () => {
+  it("formats numbers without decimals", () => {
+    expect(formatInt(42)).not.toContain(".");
+    expect(formatInt(3.7)).not.toContain(".");
+  });
+
+  it("handles zero", () => {
+    expect(formatInt(0)).toBe("0");
+  });
+
+  it("handles large numbers", () => {
+    const result = formatInt(1_000_000);
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).not.toContain(".");
+  });
+});

--- a/apps/electron/src/cache.test.ts
+++ b/apps/electron/src/cache.test.ts
@@ -1,0 +1,60 @@
+const mockStore = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock("@electron/store", () => ({
+  store: mockStore,
+}));
+
+import { getAccountCache } from "@electron/cache";
+
+describe("getAccountCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty array when store has no accounts", () => {
+    mockStore.get.mockReturnValue({});
+    expect(getAccountCache()).toEqual([]);
+  });
+
+  it("returns empty array when store.get returns undefined", () => {
+    mockStore.get.mockReturnValue(undefined);
+    expect(getAccountCache()).toEqual([]);
+  });
+
+  it("filters out inactive accounts", () => {
+    mockStore.get.mockReturnValue({
+      "acc-1": { active: false, name: "Inactive" },
+      "acc-2": { active: undefined, name: "Also Inactive" },
+    });
+    expect(getAccountCache()).toEqual([]);
+  });
+
+  it("includes only active accounts", () => {
+    mockStore.get.mockReturnValue({
+      "acc-1": { active: true, name: "Active" },
+    });
+    const result = getAccountCache();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ id: "acc-1", active: true, name: "Active" });
+  });
+
+  it("adds id field from object keys", () => {
+    mockStore.get.mockReturnValue({
+      "my-account-id": { active: true },
+    });
+    const result = getAccountCache();
+    expect(result[0].id).toBe("my-account-id");
+  });
+
+  it("handles multiple accounts, some active some not", () => {
+    mockStore.get.mockReturnValue({
+      "acc-1": { active: true, name: "First" },
+      "acc-2": { active: false, name: "Second" },
+      "acc-3": { active: true, name: "Third" },
+      "acc-4": { active: null, name: "Fourth" },
+    });
+    const result = getAccountCache();
+    expect(result).toHaveLength(2);
+    expect(result.map((a) => a.id)).toEqual(["acc-1", "acc-3"]);
+  });
+});

--- a/apps/electron/src/cache.test.ts
+++ b/apps/electron/src/cache.test.ts
@@ -35,7 +35,11 @@ describe("getAccountCache", () => {
     });
     const result = getAccountCache();
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({ id: "acc-1", active: true, name: "Active" });
+    expect(result[0]).toMatchObject({
+      id: "acc-1",
+      active: true,
+      name: "Active",
+    });
   });
 
   it("adds id field from object keys", () => {
@@ -43,7 +47,7 @@ describe("getAccountCache", () => {
       "my-account-id": { active: true },
     });
     const result = getAccountCache();
-    expect(result[0].id).toBe("my-account-id");
+    expect(result[0]?.id).toBe("my-account-id");
   });
 
   it("handles multiple accounts, some active some not", () => {

--- a/apps/electron/src/deeplink.test.ts
+++ b/apps/electron/src/deeplink.test.ts
@@ -1,0 +1,77 @@
+vi.mock("@blinkdisk/constants/app", () => ({
+  APP_SCHEME: "blinkdisk",
+  APP_SCHEME_PROTOCOL: "blinkdisk:",
+}));
+
+vi.mock("@electron/auth", () => ({
+  authenticateToken: vi.fn(),
+}));
+
+vi.mock("@electron/window", () => ({
+  focusWindow: vi.fn(),
+  sendWindow: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    setAsDefaultProtocolClient: vi.fn(() => true),
+    on: vi.fn(),
+  },
+}));
+
+import { authenticateToken } from "@electron/auth";
+import { sendWindow } from "@electron/window";
+import { onDeeplinkOpen } from "@electron/deeplink";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("onDeeplinkOpen", () => {
+  it("ignores invalid/malformed URLs", async () => {
+    await expect(onDeeplinkOpen("not-a-valid-url")).resolves.toBeUndefined();
+    expect(sendWindow).not.toHaveBeenCalled();
+    expect(authenticateToken).not.toHaveBeenCalled();
+  });
+
+  it("ignores URLs with wrong protocol", async () => {
+    await onDeeplinkOpen("https://example.com");
+
+    expect(sendWindow).not.toHaveBeenCalled();
+    expect(authenticateToken).not.toHaveBeenCalled();
+  });
+
+  it("sends deeplink.onOpen event for valid protocol URL", async () => {
+    await onDeeplinkOpen("blinkdisk://settings");
+
+    expect(sendWindow).toHaveBeenCalledWith("deeplink.onOpen", { event: "settings" });
+  });
+
+  it("extracts and authenticates token from auth callback URL", async () => {
+    await onDeeplinkOpen("blinkdisk://auth/callback#token=mytoken123");
+
+    expect(sendWindow).toHaveBeenCalledWith("deeplink.onOpen", { event: "auth" });
+    expect(authenticateToken).toHaveBeenCalledWith({ token: "mytoken123" });
+  });
+
+  it("does not authenticate when hash doesn't start with #token=", async () => {
+    await onDeeplinkOpen("blinkdisk://auth/callback#other=value");
+
+    expect(sendWindow).toHaveBeenCalledWith("deeplink.onOpen", { event: "auth" });
+    expect(authenticateToken).not.toHaveBeenCalled();
+  });
+
+  it("does not authenticate for non-auth hostnames", async () => {
+    await onDeeplinkOpen("blinkdisk://settings/callback#token=abc");
+
+    expect(sendWindow).toHaveBeenCalledWith("deeplink.onOpen", { event: "settings" });
+    expect(authenticateToken).not.toHaveBeenCalled();
+  });
+
+  it("does not authenticate for non-callback paths", async () => {
+    await onDeeplinkOpen("blinkdisk://auth/other#token=abc");
+
+    expect(sendWindow).toHaveBeenCalledWith("deeplink.onOpen", { event: "auth" });
+    expect(authenticateToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/electron/src/password.test.ts
+++ b/apps/electron/src/password.test.ts
@@ -1,0 +1,69 @@
+const mockStore = vi.hoisted(() => ({ get: vi.fn(), set: vi.fn() }));
+
+vi.mock("@electron/store", () => ({
+  store: mockStore,
+}));
+
+vi.mock("@electron/encryption", () => ({
+  encryptString: vi.fn((str: string) => `encrypted:${str}`),
+  decryptString: vi.fn((str: string) => str.replace("encrypted:", "")),
+}));
+
+import { setPasswordCache, getPasswordCache } from "@electron/password";
+import { encryptString, decryptString } from "@electron/encryption";
+
+describe("setPasswordCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("encrypts the password and stores it with correct key", () => {
+    setPasswordCache({ vaultId: "vault-1", password: "my-secret" });
+
+    expect(encryptString).toHaveBeenCalledWith("my-secret");
+    expect(mockStore.set).toHaveBeenCalledWith(
+      "passwords.vault-1",
+      "encrypted:my-secret",
+    );
+  });
+
+  it("uses the vaultId in the store key", () => {
+    setPasswordCache({ vaultId: "abc-123", password: "pw" });
+
+    expect(mockStore.set).toHaveBeenCalledWith(
+      "passwords.abc-123",
+      expect.anything(),
+    );
+  });
+});
+
+describe("getPasswordCache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when no password stored", () => {
+    mockStore.get.mockReturnValue(null);
+    expect(getPasswordCache({ vaultId: "vault-1" })).toBeNull();
+  });
+
+  it("returns null when store returns undefined", () => {
+    mockStore.get.mockReturnValue(undefined);
+    expect(getPasswordCache({ vaultId: "vault-1" })).toBeNull();
+  });
+
+  it("decrypts and returns password when stored", () => {
+    mockStore.get.mockReturnValue("encrypted:my-secret");
+    const result = getPasswordCache({ vaultId: "vault-1" });
+
+    expect(decryptString).toHaveBeenCalledWith("encrypted:my-secret", null);
+    expect(result).toBe("my-secret");
+  });
+
+  it("reads from the correct store key using vaultId", () => {
+    mockStore.get.mockReturnValue(null);
+    getPasswordCache({ vaultId: "xyz-789" });
+
+    expect(mockStore.get).toHaveBeenCalledWith("passwords.xyz-789");
+  });
+});

--- a/apps/electron/src/path.test.ts
+++ b/apps/electron/src/path.test.ts
@@ -1,0 +1,76 @@
+vi.mock("electron", () => ({
+  app: {
+    getPath: vi.fn(() => "/mock/appData"),
+    isPackaged: false,
+  },
+}));
+
+import { app } from "electron";
+import {
+  platform,
+  globalConfigDirectory,
+  globalVaultDirectory,
+  globalAccountDirectory,
+  corePath,
+} from "@electron/path";
+
+describe("platform", () => {
+  it("is one of win, mac, or linux", () => {
+    expect(["win", "mac", "linux"]).toContain(platform);
+  });
+});
+
+describe("globalConfigDirectory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (app as any).isPackaged = false;
+  });
+
+  it("contains blinkdisk-dev in dev mode", () => {
+    expect(globalConfigDirectory()).toContain("blinkdisk-dev");
+  });
+
+  it("contains blinkdisk (not blinkdisk-dev) in packaged mode", () => {
+    (app as any).isPackaged = true;
+    const dir = globalConfigDirectory();
+    expect(dir).toContain("blinkdisk");
+    expect(dir).not.toContain("blinkdisk-dev");
+  });
+});
+
+describe("globalVaultDirectory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (app as any).isPackaged = false;
+  });
+
+  it("ends with vaults", () => {
+    expect(globalVaultDirectory()).toMatch(/vaults$/);
+  });
+
+  it("starts with globalConfigDirectory", () => {
+    expect(globalVaultDirectory()).toContain(globalConfigDirectory());
+  });
+});
+
+describe("globalAccountDirectory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (app as any).isPackaged = false;
+  });
+
+  it("ends with accounts", () => {
+    expect(globalAccountDirectory()).toMatch(/accounts$/);
+  });
+});
+
+describe("corePath", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (app as any).isPackaged = false;
+  });
+
+  it("contains go/bin/core in dev mode", () => {
+    expect(corePath()).toContain("go/bin/core");
+  });
+});

--- a/apps/electron/src/profile.test.ts
+++ b/apps/electron/src/profile.test.ts
@@ -1,0 +1,113 @@
+vi.mock("@electron/path", () => ({
+  globalVaultDirectory: vi.fn(() => "/mock/vaults"),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock("node:os", () => ({
+  userInfo: vi.fn(() => ({ username: "testuser" })),
+  hostname: vi.fn(() => "testhost.local"),
+}));
+
+import { existsSync, readFileSync } from "node:fs";
+import { hostname, userInfo } from "node:os";
+import { getHostName, getUserName } from "@electron/profile";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getUserName", () => {
+  it("returns username from config file when it exists", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ username: "configuser", hostname: "confighost" }),
+    );
+
+    expect(getUserName("vault1")).toBe("configuser");
+  });
+
+  it("falls back to OS username when config has no username field", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ hostname: "confighost" }));
+
+    expect(getUserName("vault1")).toBe("testuser");
+  });
+
+  it("falls back to OS username when config file doesn't exist", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(getUserName("vault1")).toBe("testuser");
+  });
+
+  it('returns "nobody" when OS userInfo throws', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(userInfo).mockImplementation(() => {
+      throw new Error("no user");
+    });
+
+    expect(getUserName("vault1")).toBe("nobody");
+  });
+
+  it("strips domain prefix on win32", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(userInfo).mockReturnValue({ username: "DOMAIN\\user" } as ReturnType<typeof userInfo>);
+
+    expect(getUserName("vault1")).toBe("user");
+
+    Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+  });
+});
+
+describe("getHostName", () => {
+  it("returns hostname from config file when it exists", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ username: "configuser", hostname: "confighost" }),
+    );
+
+    expect(getHostName("vault1")).toBe("confighost");
+  });
+
+  it("falls back to OS hostname when config has no hostname field", () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ username: "configuser" }));
+
+    expect(getHostName("vault1")).toBe("testhost");
+  });
+
+  it("falls back to OS hostname when config file doesn't exist", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    expect(getHostName("vault1")).toBe("testhost");
+  });
+
+  it("strips domain suffix from hostname", () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(hostname).mockReturnValue("myhost.example.com");
+
+    expect(getHostName("vault1")).toBe("myhost");
+  });
+
+  it('returns "nohost" when OS hostname throws', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(hostname).mockImplementation(() => {
+      throw new Error("no hostname");
+    });
+
+    expect(getHostName("vault1")).toBe("nohost");
+  });
+
+  it('returns "nohost" when hostname is empty string', () => {
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(hostname).mockReturnValue("");
+
+    expect(getHostName("vault1")).toBe("nohost");
+  });
+});

--- a/apps/electron/src/protocol.test.ts
+++ b/apps/electron/src/protocol.test.ts
@@ -1,0 +1,60 @@
+vi.mock("@blinkdisk/constants/app", () => ({
+  INTERNAL_SCHEME: "app",
+  PROTOCOL_API_NS: "api",
+  PROTOCOL_FRONTEND_NS: "frontend",
+  PROTOCOL_VAULT_NS: "vault",
+}));
+vi.mock("@blinkdisk/constants/header", () => ({ ACCOUNT_ID_HEADER: "x-account-id" }));
+vi.mock("@electron/auth", () => ({ getAccountCookie: vi.fn() }));
+vi.mock("@electron/vault/fetch", () => ({ fetchVaultRaw: vi.fn() }));
+vi.mock("@electron/vault/manage", () => ({ getVault: vi.fn() }));
+vi.mock("electron", () => ({
+  app: { isPackaged: false },
+  net: { fetch: vi.fn() },
+  protocol: { registerSchemesAsPrivileged: vi.fn(), handle: vi.fn() },
+}));
+
+import path from "node:path";
+import { resolveProtocolPath, isPathSafe } from "@electron/protocol";
+
+describe("resolveProtocolPath", () => {
+  const baseDir = "/srv/frontend";
+
+  it('maps "/" to "index.html" within baseDir', () => {
+    const result = resolveProtocolPath(baseDir, "/");
+    expect(result).toBe(path.resolve(baseDir, "index.html"));
+  });
+
+  it('maps "/app.js" to "app.js" within baseDir', () => {
+    const result = resolveProtocolPath(baseDir, "/app.js");
+    expect(result).toBe(path.resolve(baseDir, "app.js"));
+  });
+
+  it('maps "/assets/style.css" to "assets/style.css" within baseDir', () => {
+    const result = resolveProtocolPath(baseDir, "/assets/style.css");
+    expect(result).toBe(path.resolve(baseDir, "assets/style.css"));
+  });
+});
+
+describe("isPathSafe", () => {
+  const baseDir = "/srv/frontend";
+
+  it("returns true for paths within baseDir", () => {
+    const filePath = path.resolve(baseDir, "index.html");
+    expect(isPathSafe(baseDir, filePath)).toBe(true);
+  });
+
+  it("returns false for path traversal", () => {
+    const filePath = path.resolve(baseDir, "../../etc/passwd");
+    expect(isPathSafe(baseDir, filePath)).toBe(false);
+  });
+
+  it("returns false for absolute paths outside baseDir", () => {
+    expect(isPathSafe(baseDir, "/etc/passwd")).toBe(false);
+  });
+
+  it("returns true for nested paths", () => {
+    const filePath = path.resolve(baseDir, "assets/js/main.js");
+    expect(isPathSafe(baseDir, filePath)).toBe(true);
+  });
+});

--- a/apps/electron/src/protocol.ts
+++ b/apps/electron/src/protocol.ts
@@ -29,6 +29,25 @@ export function registerProtcol() {
   ]);
 }
 
+export function resolveProtocolPath(
+  baseDir: string,
+  pathname: string,
+): string {
+  return path.resolve(
+    baseDir,
+    pathname === "/" ? "index.html" : pathname.slice(1),
+  );
+}
+
+export function isPathSafe(baseDir: string, filePath: string): boolean {
+  const relativePath = path.relative(baseDir, filePath);
+  return (
+    !!relativePath &&
+    !relativePath.startsWith("..") &&
+    !path.isAbsolute(relativePath)
+  );
+}
+
 export function listenProtocol() {
   protocol.handle(INTERNAL_SCHEME, async (req) => {
     const { host, pathname, search } = new URL(req.url);
@@ -38,17 +57,8 @@ export function listenProtocol() {
         ? path.join(import.meta.dirname, "..", "frontend")
         : path.join(process.resourcesPath, "app.asar", "frontend");
 
-      const pathToServe = path.resolve(
-        baseDir,
-        pathname === "/" ? "index.html" : pathname.slice(1),
-      );
-
-      const relativePath = path.relative(baseDir, pathToServe);
-
-      const isSafe =
-        relativePath &&
-        !relativePath.startsWith("..") &&
-        !path.isAbsolute(relativePath);
+      const pathToServe = resolveProtocolPath(baseDir, pathname);
+      const isSafe = isPathSafe(baseDir, pathToServe);
 
       if (!isSafe) {
         return new Response("Path not allowed", {

--- a/apps/electron/src/restore.test.ts
+++ b/apps/electron/src/restore.test.ts
@@ -1,0 +1,59 @@
+vi.mock("@blinkdisk/schemas/directory", () => ({}));
+vi.mock("@electron/fs", () => ({ fileExists: vi.fn() }));
+vi.mock("@electron/vault/fetch", () => ({ fetchVault: vi.fn() }));
+vi.mock("@electron/vault/manage", () => ({ getVault: vi.fn() }));
+vi.mock("@electron/window", () => ({ window: null }));
+vi.mock("electron", () => ({ app: { getPath: vi.fn() }, dialog: { showOpenDialog: vi.fn() } }));
+
+import { splitFileName, generateDuplicateName } from "@electron/restore";
+
+describe("splitFileName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('splits "photo.jpg" into baseName and extension', () => {
+    expect(splitFileName("photo.jpg")).toEqual({ baseName: "photo", extension: "jpg" });
+  });
+
+  it('splits "archive.tar.gz" keeping compound base name', () => {
+    expect(splitFileName("archive.tar.gz")).toEqual({ baseName: "archive.tar", extension: "gz" });
+  });
+
+  it('handles "README" with no extension', () => {
+    expect(splitFileName("README")).toEqual({ baseName: "README", extension: "" });
+  });
+
+  it('handles ".gitignore" as empty baseName with extension', () => {
+    expect(splitFileName(".gitignore")).toEqual({ baseName: "", extension: "gitignore" });
+  });
+
+  it('splits "file.name.with.dots.txt" correctly', () => {
+    expect(splitFileName("file.name.with.dots.txt")).toEqual({
+      baseName: "file.name.with.dots",
+      extension: "txt",
+    });
+  });
+});
+
+describe("generateDuplicateName", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("generates duplicate name with extension", () => {
+    expect(generateDuplicateName("photo", "jpg", 1)).toBe("photo (1).jpg");
+  });
+
+  it("generates duplicate name with higher counter", () => {
+    expect(generateDuplicateName("photo", "jpg", 2)).toBe("photo (2).jpg");
+  });
+
+  it("generates duplicate name without extension", () => {
+    expect(generateDuplicateName("README", "", 1)).toBe("README (1)");
+  });
+
+  it("generates duplicate name with compound base name", () => {
+    expect(generateDuplicateName("archive.tar", "gz", 3)).toBe("archive.tar (3).gz");
+  });
+});

--- a/apps/electron/src/restore.ts
+++ b/apps/electron/src/restore.ts
@@ -27,6 +27,28 @@ export type RestoreItem = {
   type: "FILE" | "SYMLINK" | "DIRECTORY";
 };
 
+export function splitFileName(name: string): {
+  baseName: string;
+  extension: string;
+} {
+  const parts = name.split(".");
+  if (parts.length > 1) {
+    return {
+      baseName: parts.slice(0, -1).join("."),
+      extension: parts.at(-1) || "",
+    };
+  }
+  return { baseName: name, extension: "" };
+}
+
+export function generateDuplicateName(
+  baseName: string,
+  extension: string,
+  counter: number,
+): string {
+  return `${baseName} (${counter})${extension ? `.${extension}` : ""}`;
+}
+
 async function restore(
   item: RestoreItem,
   directory: string,
@@ -37,18 +59,13 @@ async function restore(
   const pathExists = await fileExists(path);
 
   if (pathExists) {
-    const fileNameParts = item.name.split(".");
-    const fileExtension = fileNameParts.length > 1 ? fileNameParts.at(-1) : "";
-    const fileBaseName =
-      fileNameParts.length > 1
-        ? fileNameParts.slice(0, -1).join(".")
-        : item.name;
+    const { baseName: fileBaseName, extension: fileExtension } = splitFileName(item.name);
 
     let counter = 1;
     while (true) {
       const newPath = join(
         directory,
-        `${fileBaseName} (${counter++})${fileExtension ? `.${fileExtension}` : ""}`,
+        generateDuplicateName(fileBaseName, fileExtension, counter++),
       );
 
       const exists = await fileExists(newPath);

--- a/apps/electron/src/shell.test.ts
+++ b/apps/electron/src/shell.test.ts
@@ -1,0 +1,47 @@
+vi.mock("electron", () => ({
+  shell: { openExternal: vi.fn() },
+}));
+
+import { shell } from "electron";
+import { openBrowser } from "@electron/shell";
+
+describe("openBrowser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("opens http URLs", () => {
+    openBrowser("http://example.com");
+    expect(shell.openExternal).toHaveBeenCalledWith("http://example.com/");
+  });
+
+  it("opens https URLs", () => {
+    openBrowser("https://example.com/path");
+    expect(shell.openExternal).toHaveBeenCalledWith(
+      "https://example.com/path",
+    );
+  });
+
+  it("opens mailto URLs", () => {
+    openBrowser("mailto:test@example.com");
+    expect(shell.openExternal).toHaveBeenCalledWith(
+      "mailto:test@example.com",
+    );
+  });
+
+  it("does not open file: URLs", () => {
+    const result = openBrowser("file:///etc/passwd");
+    expect(result).toBeUndefined();
+    expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("does not open javascript: URLs", () => {
+    const result = openBrowser("javascript:alert(1)");
+    expect(result).toBeUndefined();
+    expect(shell.openExternal).not.toHaveBeenCalled();
+  });
+
+  it("throws on malformed URLs", () => {
+    expect(() => openBrowser("not-a-url")).toThrow();
+  });
+});

--- a/apps/electron/src/theme.test.ts
+++ b/apps/electron/src/theme.test.ts
@@ -1,0 +1,53 @@
+const mockStore = vi.hoisted(() => ({ get: vi.fn() }));
+const mockNativeTheme = vi.hoisted(() => ({ shouldUseDarkColors: false }));
+
+vi.mock("@electron/store", () => ({
+  store: mockStore,
+}));
+
+vi.mock("electron/main", () => ({
+  nativeTheme: mockNativeTheme,
+}));
+
+import { getTheme } from "@electron/theme";
+
+describe("getTheme", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockNativeTheme.shouldUseDarkColors = false;
+  });
+
+  it("returns dark when preference is dark", () => {
+    mockStore.get.mockReturnValue("dark");
+    expect(getTheme()).toBe("dark");
+  });
+
+  it("returns light when preference is light", () => {
+    mockStore.get.mockReturnValue("light");
+    expect(getTheme()).toBe("light");
+  });
+
+  it("returns dark when preference is system and system is dark", () => {
+    mockStore.get.mockReturnValue("system");
+    mockNativeTheme.shouldUseDarkColors = true;
+    expect(getTheme()).toBe("dark");
+  });
+
+  it("returns light when preference is system and system is light", () => {
+    mockStore.get.mockReturnValue("system");
+    mockNativeTheme.shouldUseDarkColors = false;
+    expect(getTheme()).toBe("light");
+  });
+
+  it("returns system theme when preference is undefined", () => {
+    mockStore.get.mockReturnValue(undefined);
+    mockNativeTheme.shouldUseDarkColors = true;
+    expect(getTheme()).toBe("dark");
+  });
+
+  it("returns system theme when preference is null", () => {
+    mockStore.get.mockReturnValue(null);
+    mockNativeTheme.shouldUseDarkColors = false;
+    expect(getTheme()).toBe("light");
+  });
+});

--- a/apps/electron/src/vault/server.test.ts
+++ b/apps/electron/src/vault/server.test.ts
@@ -1,0 +1,96 @@
+vi.mock("@blinkdisk/utils/id", () => ({ generateId: vi.fn(() => "mock-id") }));
+vi.mock("@blinkdisk/utils/try-catch", () => ({ tryCatch: vi.fn() }));
+vi.mock("@electron/log", () => ({ log: { info: vi.fn(), error: vi.fn() } }));
+vi.mock("@electron/path", () => ({ corePath: vi.fn(), globalVaultDirectory: vi.fn(() => "/mock") }));
+vi.mock("@electron/vault/fetch", () => ({ fetchVault: vi.fn() }));
+vi.mock("@electron/vault/manage", () => ({ vaults: {} }));
+vi.mock("@electron/window", () => ({ sendWindow: vi.fn() }));
+vi.mock("child_process", () => ({ spawn: vi.fn() }));
+vi.mock("electron", () => ({ app: { isPackaged: false } }));
+vi.mock("tough-cookie", () => ({ CookieJar: vi.fn() }));
+
+import { parseServerLine, calculateStatusPollDelay } from "@electron/vault/server";
+
+describe("parseServerLine", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses SERVER ADDRESS line", () => {
+    const result = parseServerLine("SERVER ADDRESS: https://127.0.0.1:12345");
+    expect(result).toEqual({ key: "SERVER ADDRESS", value: "https://127.0.0.1:12345" });
+  });
+
+  it("parses SERVER PASSWORD line", () => {
+    const result = parseServerLine("SERVER PASSWORD: abc123");
+    expect(result).toEqual({ key: "SERVER PASSWORD", value: "abc123" });
+  });
+
+  it("parses SERVER CONTROL PASSWORD line", () => {
+    const result = parseServerLine("SERVER CONTROL PASSWORD: xyz789");
+    expect(result).toEqual({ key: "SERVER CONTROL PASSWORD", value: "xyz789" });
+  });
+
+  it("parses SERVER CERT SHA256 line", () => {
+    const result = parseServerLine("SERVER CERT SHA256: abcdef");
+    expect(result).toEqual({ key: "SERVER CERT SHA256", value: "abcdef" });
+  });
+
+  it("parses SERVER CERTIFICATE line and decodes base64", () => {
+    const encoded = Buffer.from("hello").toString("base64");
+    const result = parseServerLine(`SERVER CERTIFICATE: ${encoded}`);
+    expect(result).toEqual({ key: "SERVER CERTIFICATE", value: encoded, decoded: "hello" });
+  });
+
+  it("parses BDC SPACE UPDATE line with JSON", () => {
+    const result = parseServerLine('BDC SPACE UPDATE: {"used":100}');
+    expect(result).toEqual({ key: "BDC SPACE UPDATE", value: '{"used":100}', parsed: { used: 100 } });
+  });
+
+  it("returns BDC VAULT DELETED for vault deleted lines", () => {
+    const result = parseServerLine("BDC VAULT DELETED: ");
+    expect(result).toEqual({ key: "BDC VAULT DELETED" });
+  });
+
+  it("returns NOTIFICATION for notification lines", () => {
+    const result = parseServerLine("NOTIFICATION: something");
+    expect(result).toEqual({ key: "NOTIFICATION" });
+  });
+
+  it("returns null for lines without delimiter", () => {
+    const result = parseServerLine("no delimiter here");
+    expect(result).toBeNull();
+  });
+
+  it("returns unknown for unrecognized keys", () => {
+    const line = "SOME OTHER KEY: value";
+    const result = parseServerLine(line);
+    expect(result).toEqual({ key: "unknown", raw: line });
+  });
+});
+
+describe("calculateStatusPollDelay", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 100 for iteration 1", () => {
+    expect(calculateStatusPollDelay(1)).toBe(100);
+  });
+
+  it("returns 500 for iteration 5", () => {
+    expect(calculateStatusPollDelay(5)).toBe(500);
+  });
+
+  it("returns 900 for iteration 9", () => {
+    expect(calculateStatusPollDelay(9)).toBe(900);
+  });
+
+  it("returns 1000 for iteration 10", () => {
+    expect(calculateStatusPollDelay(10)).toBe(1000);
+  });
+
+  it("returns 1000 for iteration 100", () => {
+    expect(calculateStatusPollDelay(100)).toBe(1000);
+  });
+});

--- a/apps/electron/src/vault/server.ts
+++ b/apps/electron/src/vault/server.ts
@@ -207,3 +207,54 @@ async function startStatusPool(id: string) {
     await new Promise((res) => setTimeout(res, delay));
   }
 }
+
+export type ParsedServerLine =
+  | { key: "SERVER ADDRESS"; value: string }
+  | { key: "SERVER PASSWORD"; value: string }
+  | { key: "SERVER CONTROL PASSWORD"; value: string }
+  | { key: "SERVER CERT SHA256"; value: string }
+  | { key: "SERVER CERTIFICATE"; value: string; decoded: string }
+  | { key: "BDC SPACE UPDATE"; value: string; parsed: unknown }
+  | { key: "BDC VAULT DELETED" }
+  | { key: "NOTIFICATION" }
+  | { key: "unknown"; raw: string }
+  | null;
+
+export function parseServerLine(line: string): ParsedServerLine {
+  const delimiter = line.indexOf(": ");
+  if (delimiter < 0) return null;
+
+  const key = line.substring(0, delimiter);
+  const value = line.substring(delimiter + 2) || "";
+
+  switch (key) {
+    case "SERVER ADDRESS":
+    case "SERVER PASSWORD":
+    case "SERVER CONTROL PASSWORD":
+    case "SERVER CERT SHA256":
+      return { key, value };
+
+    case "SERVER CERTIFICATE":
+      return {
+        key,
+        value,
+        decoded: Buffer.from(value, "base64").toString("ascii"),
+      };
+
+    case "BDC SPACE UPDATE":
+      return { key, value, parsed: JSON.parse(value) };
+
+    case "BDC VAULT DELETED":
+      return { key: "BDC VAULT DELETED" };
+
+    case "NOTIFICATION":
+      return { key: "NOTIFICATION" };
+
+    default:
+      return { key: "unknown", raw: line };
+  }
+}
+
+export function calculateStatusPollDelay(iteration: number): number {
+  return iteration < 10 ? 100 * iteration : 1000;
+}

--- a/apps/electron/src/vault/server.ts
+++ b/apps/electron/src/vault/server.ts
@@ -57,38 +57,35 @@ export function startVaultServer(id: string, pollStatus = true) {
     process?.stderr.on("data", (data) => {
       const lines = (data + "").split("\n");
 
-      for (let i = 0; i < lines.length; i++) {
-        const delimiter = lines[i]?.indexOf(": ") || 0;
-        if (delimiter < 0) continue;
+      for (const line of lines) {
+        const parsed = parseServerLine(line);
+        if (!parsed) continue;
 
-        const key = lines[i]?.substring(0, delimiter);
-        const value = lines[i]?.substring(delimiter + 2) || "";
-
-        switch (key) {
+        switch (parsed.key) {
           case "SERVER ADDRESS":
-            address = value;
+            address = parsed.value;
             break;
 
           case "SERVER PASSWORD":
-            password = value;
+            password = parsed.value;
             break;
 
           case "SERVER CONTROL PASSWORD":
-            controlPassword = value;
+            controlPassword = parsed.value;
             break;
 
           case "SERVER CERT SHA256":
-            certificateHash = value;
+            certificateHash = parsed.value;
             break;
 
           case "SERVER CERTIFICATE":
-            certificate = Buffer.from(value, "base64").toString("ascii");
+            certificate = parsed.decoded;
             break;
 
           case "BDC SPACE UPDATE":
             sendWindow("space.update", {
               vaultId: id,
-              space: JSON.parse(value),
+              space: parsed.parsed,
             });
             break;
 
@@ -99,14 +96,6 @@ export function startVaultServer(id: string, pollStatus = true) {
           // TODO: Handle notification events
           case "NOTIFICATION":
             break;
-
-          //   const [notification, parseError] = tryCatch(() => JSON.parse(value));
-          //   if (parseError)
-          //      return log.error(
-          //        `Failed to parse notification for ${this.id}: ${parseError}`,
-          //      );
-          //   this.handleNotification(notification);
-          //   break;
 
           default:
             logFormatted(id, data);
@@ -197,7 +186,7 @@ async function startStatusPool(id: string) {
     else vaultStatus = "SETUP";
 
     i = i + 1;
-    const delay = i < 10 ? 100 * i : 1000;
+    const delay = calculateStatusPollDelay(i);
 
     if (vaults[id]) {
       vaults[id].status = vaultStatus;

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "lint": "eslint . --max-warnings 0",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "vitest run"
   },
   "exports": {
     "./*": "./src/*.ts"
@@ -15,7 +16,9 @@
     "@types/node": "^22.13.9",
     "@types/nodemailer": "^7.0.4",
     "eslint": "^9.22.0",
-    "typescript": "5.8.2"
+    "typescript": "5.8.2",
+    "vitest": "^3.1.1",
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "dependencies": {
     "@blinkdisk/constants": "workspace:*",

--- a/libs/utils/src/format.test.ts
+++ b/libs/utils/src/format.test.ts
@@ -1,0 +1,57 @@
+import { formatSubscriptionEn } from "./format";
+
+describe("formatSubscriptionEn", () => {
+  it("formats valid plan with monthly price", () => {
+    const result = formatSubscriptionEn(
+      { storageGB: 100 },
+      { amount: 5, currency: "USD", period: "MONTHLY" },
+    );
+    expect(result).toContain("GB");
+    expect(result).toContain("/mo");
+  });
+
+  it("formats valid plan with yearly price", () => {
+    const result = formatSubscriptionEn(
+      { storageGB: 100 },
+      { amount: 50, currency: "USD", period: "YEARLY" },
+    );
+    expect(result).toContain("GB");
+    expect(result).toContain("/yr");
+  });
+
+  it("shows question mark for undefined plan", () => {
+    const result = formatSubscriptionEn(undefined, {
+      amount: 5,
+      currency: "USD",
+      period: "MONTHLY",
+    });
+    expect(result).toMatch(/^\? GB/);
+  });
+
+  it("shows question marks for undefined price", () => {
+    const result = formatSubscriptionEn({ storageGB: 100 }, undefined);
+    expect(result).toContain("?/?");
+  });
+
+  it("shows all question marks when both undefined", () => {
+    const result = formatSubscriptionEn(undefined, undefined);
+    expect(result).toBe("? GB (?/?)");
+  });
+
+  it("shows dash for unknown period", () => {
+    const result = formatSubscriptionEn(
+      { storageGB: 100 },
+      { amount: 5, currency: "USD", period: "WEEKLY" },
+    );
+    expect(result).toContain("/-");
+  });
+
+  it("formats large storage numbers with locale separators", () => {
+    const result = formatSubscriptionEn(
+      { storageGB: 1000 },
+      { amount: 10, currency: "USD", period: "MONTHLY" },
+    );
+    // toLocaleString() should add separators (e.g. "1,000" in en-US)
+    expect(result).toMatch(/1[,.]000/);
+  });
+});

--- a/libs/utils/src/id.test.ts
+++ b/libs/utils/src/id.test.ts
@@ -1,0 +1,88 @@
+import { generateId, generateCode, verifyId, type Prefix } from "./id";
+
+describe("generateId", () => {
+  it("returns a string of length 21 without prefix", () => {
+    const id = generateId();
+    expect(id).toHaveLength(21);
+  });
+
+  it("generates a valid id that passes verification", () => {
+    const id = generateId();
+    expect(verifyId(id)).toBe(true);
+  });
+
+  it("prefixes with 'acct_' for Account", () => {
+    const id = generateId("Account");
+    expect(id).toMatch(/^acct_/);
+  });
+
+  it("prefixes with 'vlt_' for Vault", () => {
+    const id = generateId("Vault");
+    expect(id).toMatch(/^vlt_/);
+  });
+
+  it("produces correct prefix for every prefix key", () => {
+    const expectedPrefixes: Record<Prefix, string> = {
+      Account: "acct",
+      AuthMethod: "auth",
+      Session: "sesh",
+      Verification: "ver",
+      Queue: "que",
+      Device: "dev",
+      Profile: "prf",
+      Vault: "vlt",
+      Config: "cfg",
+      Folder: "fld",
+      Space: "spc",
+      Subscription: "sub",
+    };
+
+    for (const [key, prefix] of Object.entries(expectedPrefixes)) {
+      const id = generateId(key as Prefix);
+      expect(id).toMatch(new RegExp(`^${prefix}_`));
+    }
+  });
+
+  it("generates unique ids", () => {
+    const id1 = generateId();
+    const id2 = generateId();
+    expect(id1).not.toBe(id2);
+  });
+});
+
+describe("verifyId", () => {
+  it("returns true for a valid unprefixed id", () => {
+    const id = generateId();
+    expect(verifyId(id)).toBe(true);
+  });
+
+  it("returns true for a valid prefixed id", () => {
+    const id = generateId("Vault");
+    expect(verifyId(id)).toBe(true);
+  });
+
+  it("returns false for an invalid id", () => {
+    expect(verifyId("totally-invalid-id!!")).toBe(false);
+  });
+
+  it("returns false for wrong length", () => {
+    expect(verifyId("short")).toBe(false);
+  });
+});
+
+describe("generateCode", () => {
+  it("returns a string of default length 21", () => {
+    const code = generateCode();
+    expect(code).toHaveLength(21);
+  });
+
+  it("returns a string of specified length", () => {
+    const code = generateCode(10);
+    expect(code).toHaveLength(10);
+  });
+
+  it("only contains expected characters (A-Z except O, 1-9)", () => {
+    const code = generateCode(100);
+    expect(code).toMatch(/^[ABCDEFGHIJKLMNPQRSTUVWXYZ123456789]+$/);
+  });
+});

--- a/libs/utils/src/object.test.ts
+++ b/libs/utils/src/object.test.ts
@@ -1,0 +1,52 @@
+import { removeEmptyStrings } from "./object";
+
+describe("removeEmptyStrings", () => {
+  it("removes top-level empty strings", () => {
+    expect(removeEmptyStrings({ a: "", b: "hello" })).toEqual({ b: "hello" });
+  });
+
+  it("preserves non-string falsy values", () => {
+    expect(removeEmptyStrings({ a: 0, b: false, c: null })).toEqual({
+      a: 0,
+      b: false,
+      c: null,
+    });
+  });
+
+  it("handles nested objects", () => {
+    expect(removeEmptyStrings({ a: { b: "", c: "ok" } })).toEqual({
+      a: { c: "ok" },
+    });
+  });
+
+  it("removes nested objects that become empty", () => {
+    expect(removeEmptyStrings({ a: { b: "" } })).toEqual({});
+  });
+
+  it("preserves arrays", () => {
+    expect(removeEmptyStrings({ a: [1, 2] })).toEqual({ a: [1, 2] });
+  });
+
+  it("handles empty input", () => {
+    expect(removeEmptyStrings({})).toEqual({});
+  });
+
+  it("handles deeply nested empty strings", () => {
+    expect(removeEmptyStrings({ a: { b: { c: "" } } })).toEqual({});
+  });
+
+  it("handles mixed values correctly", () => {
+    expect(
+      removeEmptyStrings({
+        a: "keep",
+        b: "",
+        c: 42,
+        d: { e: "", f: "yes" },
+      }),
+    ).toEqual({
+      a: "keep",
+      c: 42,
+      d: { f: "yes" },
+    });
+  });
+});

--- a/libs/utils/src/token.test.ts
+++ b/libs/utils/src/token.test.ts
@@ -1,0 +1,53 @@
+import { getVaultId } from "./token";
+
+function createFakeJwt(payload: Record<string, unknown>) {
+  const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const body = btoa(JSON.stringify(payload));
+  return `${header}.${body}.fake-signature`;
+}
+
+describe("getVaultId", () => {
+  it("returns null when no Authorization header", () => {
+    const headers = new Headers();
+    expect(getVaultId(headers)).toBeNull();
+  });
+
+  it("returns null when token payload has no vault or storage id", () => {
+    const token = createFakeJwt({});
+    const headers = new Headers({
+      Authorization: `Bearer ${token}`,
+    });
+    expect(getVaultId(headers)).toBeNull();
+  });
+
+  it("throws when token is completely malformed", () => {
+    const headers = new Headers({
+      Authorization: "Bearer not-a-valid-jwt",
+    });
+    expect(() => getVaultId(headers)).toThrow();
+  });
+
+  it("returns vaultId from valid token", () => {
+    const token = createFakeJwt({ vaultId: "vlt_abc123" });
+    const headers = new Headers({ Authorization: `Bearer ${token}` });
+    expect(getVaultId(headers)).toBe("vlt_abc123");
+  });
+
+  it("migrates legacy storageId with strg_ prefix to vlt_", () => {
+    const token = createFakeJwt({ storageId: "strg_abc" });
+    const headers = new Headers({ Authorization: `Bearer ${token}` });
+    expect(getVaultId(headers)).toBe("vlt_abc");
+  });
+
+  it("falls back to storageId when vaultId is missing", () => {
+    const token = createFakeJwt({ storageId: "vlt_fallback" });
+    const headers = new Headers({ Authorization: `Bearer ${token}` });
+    expect(getVaultId(headers)).toBe("vlt_fallback");
+  });
+
+  it("returns null when neither vaultId nor storageId present", () => {
+    const token = createFakeJwt({ something: "else" });
+    const headers = new Headers({ Authorization: `Bearer ${token}` });
+    expect(getVaultId(headers)).toBeNull();
+  });
+});

--- a/libs/utils/src/try-catch.test.ts
+++ b/libs/utils/src/try-catch.test.ts
@@ -1,0 +1,66 @@
+import { tryCatch } from "./try-catch";
+import { CustomError } from "./error";
+
+describe("tryCatch", () => {
+  describe("sync function", () => {
+    it("returns value on success", () => {
+      const [data, error] = tryCatch(() => 42);
+      expect(data).toBe(42);
+      expect(error).toBeUndefined();
+    });
+
+    it("returns error on throw", () => {
+      const [data, error] = tryCatch(() => {
+        throw new Error("fail");
+      });
+      expect(data).toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("fail");
+    });
+  });
+
+  describe("async function", () => {
+    it("returns value on success", async () => {
+      const [data, error] = await tryCatch(async () => 42);
+      expect(data).toBe(42);
+      expect(error).toBeUndefined();
+    });
+
+    it("returns error on throw", async () => {
+      const [data, error] = await tryCatch(async () => {
+        throw new Error("fail");
+      });
+      expect(data).toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("fail");
+    });
+  });
+
+  describe("direct promise", () => {
+    it("returns value on resolve", async () => {
+      const [data, error] = await tryCatch(Promise.resolve(42));
+      expect(data).toBe(42);
+      expect(error).toBeUndefined();
+    });
+
+    it("returns error on rejection", async () => {
+      const [data, error] = await tryCatch(
+        Promise.reject(new Error("fail")),
+      );
+      expect(data).toBeUndefined();
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe("fail");
+    });
+  });
+
+  it("preserves custom error type", () => {
+    const customErr = new CustomError("VAULT_NOT_FOUND");
+    const [data, error] = tryCatch(() => {
+      throw customErr;
+    });
+    expect(data).toBeUndefined();
+    expect(error).toBe(customErr);
+    expect(error).toBeInstanceOf(CustomError);
+    expect((error as CustomError).code).toBe("VAULT_NOT_FOUND");
+  });
+});

--- a/libs/utils/vitest.config.ts
+++ b/libs/utils/vitest.config.ts
@@ -1,0 +1,9 @@
+import paths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [paths()],
+  test: {
+    globals: true,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1179,6 +1179,12 @@ importers:
       typescript:
         specifier: 5.8.2
         version: 5.8.2
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.2)
+      vitest:
+        specifier: ^3.1.1
+        version: 3.2.4(@types/node@22.13.10)
 
 packages:
 
@@ -9408,6 +9414,16 @@ packages:
       - supports-color
     dev: false
 
+  /@vitest/expect@3.2.4:
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+    dev: true
+
   /@vitest/expect@4.0.18:
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
     dependencies:
@@ -9417,6 +9433,23 @@ packages:
       '@vitest/utils': 4.0.18
       chai: 6.2.2
       tinyrainbow: 3.0.3
+
+  /@vitest/mocker@3.2.4(vite@6.4.1):
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      vite: 6.4.1(@types/node@22.13.10)
+    dev: true
 
   /@vitest/mocker@4.0.18(vite@6.4.1):
     resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
@@ -9434,16 +9467,38 @@ packages:
       magic-string: 0.30.21
       vite: 6.4.1(@types/node@22.13.10)
 
+  /@vitest/pretty-format@3.2.4:
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+    dependencies:
+      tinyrainbow: 2.0.0
+    dev: true
+
   /@vitest/pretty-format@4.0.18:
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
     dependencies:
       tinyrainbow: 3.0.3
+
+  /@vitest/runner@3.2.4:
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+    dev: true
 
   /@vitest/runner@4.0.18:
     resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
     dependencies:
       '@vitest/utils': 4.0.18
       pathe: 2.0.3
+
+  /@vitest/snapshot@3.2.4:
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+    dev: true
 
   /@vitest/snapshot@4.0.18:
     resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
@@ -9452,8 +9507,22 @@ packages:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  /@vitest/spy@3.2.4:
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+    dependencies:
+      tinyspy: 4.0.4
+    dev: true
+
   /@vitest/spy@4.0.18:
     resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  /@vitest/utils@3.2.4:
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+    dev: true
 
   /@vitest/utils@4.0.18:
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
@@ -10513,6 +10582,11 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /cacache@16.1.3:
     resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -10601,6 +10675,17 @@ packages:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
     dev: false
 
+  /chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+    dev: true
+
   /chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -10656,6 +10741,11 @@ packages:
   /character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
     dev: false
+
+  /check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+    dev: true
 
   /checkpoint-client@1.1.27:
     resolution: {integrity: sha512-xstymfUalJOv6ZvTtmkwP4ORJN36ikT4PvrIoLe3wstbYf87XIXCcZrSmbFQOjyB0v1qbBnCsAscDpfdZlCkFA==}
@@ -11614,6 +11704,11 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       mimic-response: 3.1.0
+
+  /deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+    dev: true
 
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -14156,6 +14251,10 @@ packages:
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
+  /js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+    dev: true
+
   /js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
@@ -14808,6 +14907,10 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+
+  /loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+    dev: true
 
   /lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -16463,6 +16566,11 @@ packages:
 
   /pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  /pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+    dev: true
 
   /pe-library@0.4.1:
     resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
@@ -18416,6 +18524,12 @@ packages:
     engines: {node: '>=14.16'}
     dev: true
 
+  /strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+    dependencies:
+      js-tokens: 9.0.1
+    dev: true
+
   /strnum@2.1.1:
     resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
 
@@ -18642,6 +18756,10 @@ packages:
     engines: {node: ^16.14.0 || >= 17.3.0}
     dev: false
 
+  /tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+    dev: true
+
   /tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -18658,9 +18776,24 @@ packages:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  /tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    dev: true
+
+  /tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /tinyrainbow@3.0.3:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
+
+  /tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+    dev: true
 
   /tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
@@ -19392,6 +19525,31 @@ packages:
       vfile-message: 4.0.3
     dev: false
 
+  /vite-node@3.2.4(@types/node@22.13.10):
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1(@types/node@22.13.10)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
+
   /vite-plugin-environment@1.1.3(vite@6.2.2):
     resolution: {integrity: sha512-9LBhB0lx+2lXVBEWxFZC+WO7PKEyE/ykJ7EPWCq95NEcCpblxamTbs5Dm3DLBGzwODpJMEnzQywJU8fw6XGGGA==}
     peerDependencies:
@@ -19654,6 +19812,73 @@ packages:
     dependencies:
       vite: 7.3.2(@types/node@22.13.10)
     dev: false
+
+  /vitest@3.2.4(@types/node@22.13.10):
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+    dependencies:
+      '@types/chai': 5.2.3
+      '@types/node': 22.13.10
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.4.1)
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@22.13.10)
+      vite-node: 3.2.4(@types/node@22.13.10)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+    dev: true
 
   /vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.13.10):
     resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add broad unit tests across desktop cron, backup/folder/number; Electron cache, deeplink, password, path/profile/protocol/restore/shell/theme; and `libs/utils` (`format`, `id`, `object`, `token`, `try-catch`) to raise coverage. Extracted small pure helpers and wired them into protocol and server to improve path safety and parsing/polling without changing behavior.

- **Refactors**
  - Extracted `resolveProtocolPath` and `isPathSafe` in `@electron/protocol`; used in `listenProtocol` to guard against path traversal.
  - Extracted `splitFileName` and `generateDuplicateName` in `@electron/restore`; applied to duplicate naming logic.
  - Extracted `parseServerLine` and `calculateStatusPollDelay` in `@electron/vault/server`; now used for server output parsing and status polling; fixed a minor type error.

- **Dependencies**
  - Added `vitest` and `vite-tsconfig-paths` in `libs/utils`; new `test` script and `vitest.config.ts`.
  - Updated `pnpm-lock.yaml`.

<sup>Written for commit 41a937f5c0eb91c7924112134c11f48abfd0df6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

