### PR TITLE
refactor(marketing): use official product names

### DIFF
--- a/apps/marketing/src/components/compare/react/PricingCalculator.tsx
+++ b/apps/marketing/src/components/compare/react/PricingCalculator.tsx
@@ -12,11 +12,11 @@ type Props = {
 };
 
 const calculators: Record<string, React.ComponentType> = {
-  acronis: AcronisPricingCalculator,
   blinkdisk: BlinkDiskPricingCalculator,
   backblaze: BackblazePricingCalculator,
   carbonite: CarbonitePricingCalculator,
   crashplan: CrashPlanPricingCalculator,
+  "acronis-true-image": AcronisPricingCalculator,
   "easeus-todo-backup": EaseUSTodoBackupPricingCalculator,
   idrive: IDrivePricingCalculator,
 };

--- a/apps/marketing/src/pages/compare/[slug].astro
+++ b/apps/marketing/src/pages/compare/[slug].astro
@@ -8,9 +8,19 @@ export const prerender = false;
 const slug = Astro.params.slug;
 if (!slug) return Astro.redirect("/404");
 
-const toolsOrUndefined = slug
-  .split("-vs-")
-  .map((slug) => COMPARISON_TOOLS.find((t) => t.slug === slug));
+const slugParts = slug.split("-vs-");
+
+const canonicalParts = slugParts.map((part) => {
+  const aliasMatch = COMPARISON_TOOLS.find((t) => t.aliases?.includes(part));
+  return aliasMatch?.slug ?? part;
+});
+
+if (canonicalParts.some((part, i) => part !== slugParts[i]))
+  return Astro.redirect(`/compare/${canonicalParts.join("-vs-")}`, 301);
+
+const toolsOrUndefined = slugParts.map((slug) =>
+  COMPARISON_TOOLS.find((t) => t.slug === slug),
+);
 
 if (
   toolsOrUndefined.some((tool) => tool === undefined) ||

--- a/libs/constants/src/comparison.ts
+++ b/libs/constants/src/comparison.ts
@@ -14,6 +14,7 @@ export type CellValue = SupportedValue | TextValue | null;
 
 export type BackupTool = {
   slug: string;
+  aliases?: string[];
   name: string;
   website: string;
   pricingUrl?: string;
@@ -222,7 +223,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
   },
   {
     slug: "backblaze",
-    name: "Backblaze",
+    name: "Backblaze Computer Backup",
     website: "https://www.backblaze.com/cloud-backup/personal",
     pricingUrl: "https://www.backblaze.com/cloud-backup/pricing",
     general: {
@@ -338,8 +339,9 @@ export const COMPARISON_TOOLS: BackupTool[] = [
     },
   },
   {
-    slug: "acronis",
-    name: "Acronis",
+    slug: "acronis-true-image",
+    aliases: ["acronis"],
+    name: "Acronis True Image",
     website: "https://www.acronis.com/en/products/true-image/",
     pricingUrl: "https://www.acronis.com/en/products/true-image/purchasing/",
     general: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use official product names in compare pages and canonicalize compare URLs. Adds alias support with 301 redirects so old links keep working.

- **Refactors**
  - Add `aliases` to `COMPARISON_TOOLS` and resolve incoming slugs to canonical slugs; 301 redirect when an alias is used (e.g., `/compare/acronis-vs-backblaze` → `/compare/acronis-true-image-vs-backblaze`).
  - Update names and slugs to official titles: "Backblaze Computer Backup" and "Acronis True Image"; change Acronis slug to `acronis-true-image` with alias `acronis`.
  - Update pricing calculator mapping to use `acronis-true-image` so the Acronis calculator loads correctly.

<sup>Written for commit fdd3c61a2af8c4330f24295523edf97465aa7de9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

