### PR TITLE
feat(marketing): add free cards to comparison

### DIFF
--- a/apps/marketing/src/components/compare/ComparisonPageContent.astro
+++ b/apps/marketing/src/components/compare/ComparisonPageContent.astro
@@ -2,9 +2,7 @@
 import Button from "@marketing/components/Button.astro";
 import ComparisonTable from "@marketing/components/compare/ComparisonTable.astro";
 import SectionHeading from "@marketing/components/compare/SectionHeading.astro";
-import PricingCalculator, {
-  hasCalculator,
-} from "@marketing/components/compare/react/PricingCalculator";
+import PricingCalculator from "@marketing/components/compare/react/PricingCalculator";
 import {
   ToolSelector,
   AddToolButton,
@@ -246,9 +244,7 @@ const paddedTools: (BackupTool | null)[] =
           {tools.map((tool) => (
             <div class="flex flex-col gap-4">
               <h4 class="text-center text-sm font-semibold">{tool.name}</h4>
-              {hasCalculator(tool.slug) ? (
-                <PricingCalculator client:load tool={tool} />
-              ) : null}
+              <PricingCalculator client:load tool={tool} />
               {tool.pricingUrl && (
                 <Button
                   href={tool.pricingUrl}

--- a/apps/marketing/src/components/compare/react/FreePricingCalculator.tsx
+++ b/apps/marketing/src/components/compare/react/FreePricingCalculator.tsx
@@ -1,0 +1,22 @@
+import { CheckIcon } from "lucide-react";
+
+export default function FreePricingCalculator() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="bg-card rounded-xl border p-4">
+        <p className="text-3xl font-bold">Free</p>
+
+        <ul className="mt-4 flex flex-col gap-2">
+          <li className="flex items-start gap-2 text-sm">
+            <CheckIcon className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+            <span>All features included</span>
+          </li>
+          <li className="flex items-start gap-2 text-sm">
+            <CheckIcon className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+            <span>Only pay for storage</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/marketing/src/components/compare/react/FreemiumPricingCalculator.tsx
+++ b/apps/marketing/src/components/compare/react/FreemiumPricingCalculator.tsx
@@ -1,0 +1,29 @@
+import { AlertTriangleIcon, CheckIcon } from "lucide-react";
+
+export default function FreemiumPricingCalculator() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="bg-card rounded-xl border p-4">
+        <p className="text-3xl font-bold">Free</p>
+
+        <ul className="mt-4 flex flex-col gap-2">
+          <li className="flex items-start gap-2 text-sm">
+            <CheckIcon className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+            <span>Some features available at no cost</span>
+          </li>
+          <li className="flex items-start gap-2 text-sm">
+            <CheckIcon className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+            <span>Pay for storage</span>
+          </li>
+        </ul>
+
+        <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
+          <AlertTriangleIcon className="mt-0.5 size-4 shrink-0 text-amber-600 dark:text-amber-500" />
+          <p className="text-xs text-amber-900 dark:text-amber-200">
+            Some features require a paid upgrade.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/marketing/src/components/compare/react/PricingCalculator.tsx
+++ b/apps/marketing/src/components/compare/react/PricingCalculator.tsx
@@ -5,6 +5,8 @@ import BlinkDiskPricingCalculator from "@marketing/components/compare/react/Blin
 import CarbonitePricingCalculator from "@marketing/components/compare/react/CarbonitePricingCalculator";
 import CrashPlanPricingCalculator from "@marketing/components/compare/react/CrashPlanPricingCalculator";
 import EaseUSTodoBackupPricingCalculator from "@marketing/components/compare/react/EaseUSTodoBackupPricingCalculator";
+import FreePricingCalculator from "@marketing/components/compare/react/FreePricingCalculator";
+import FreemiumPricingCalculator from "@marketing/components/compare/react/FreemiumPricingCalculator";
 import IDrivePricingCalculator from "@marketing/components/compare/react/IDrivePricingCalculator";
 
 type Props = {
@@ -21,16 +23,26 @@ const calculators: Record<string, React.ComponentType> = {
   idrive: IDrivePricingCalculator,
 };
 
+const pricingCalculators: Record<
+  BackupTool["pricing"],
+  React.ComponentType | null
+> = {
+  free: FreePricingCalculator,
+  freemium: FreemiumPricingCalculator,
+  custom: null,
+};
+
+function resolveCalculator(tool: BackupTool): React.ComponentType | null {
+  if (tool.slug in calculators) return calculators[tool.slug] ?? null;
+  return pricingCalculators[tool.pricing] ?? null;
+}
+
 export default function PricingCalculator({ tool }: Props) {
-  const Calculator = calculators[tool.slug];
+  const Calculator = resolveCalculator(tool);
 
   if (!Calculator) {
     return null;
   }
 
   return <Calculator />;
-}
-
-export function hasCalculator(slug: string): boolean {
-  return slug in calculators;
 }

--- a/libs/constants/src/comparison.ts
+++ b/libs/constants/src/comparison.ts
@@ -18,6 +18,7 @@ export type BackupTool = {
   name: string;
   website: string;
   pricingUrl?: string;
+  pricing: "free" | "freemium" | "custom";
   general: {
     folderBackups: CellValue;
     imageBackups: CellValue;
@@ -188,8 +189,9 @@ export const COMPARISON_TOOLS: BackupTool[] = [
     name: "BlinkDisk",
     website: "https://blinkdisk.com?utm_source=compare",
     pricingUrl: "/cloudblink#pricing",
+    pricing: "custom",
     general: {
-      releaseYear: { text: "2025", note: "Built on Kopia, released in 2021" },
+      releaseYear: { text: "2025", note: "Built on Kopia, released in 2019" },
       folderBackups: { supported: true },
       imageBackups: { supported: false },
       openSource: { supported: true },
@@ -226,6 +228,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
     name: "Backblaze Computer Backup",
     website: "https://www.backblaze.com/cloud-backup/personal",
     pricingUrl: "https://www.backblaze.com/cloud-backup/pricing",
+    pricing: "custom",
     general: {
       releaseYear: { text: "2008" },
       folderBackups: { supported: true },
@@ -267,6 +270,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
     name: "Carbonite",
     website: "https://carbonite.com",
     pricingUrl: "https://www.carbonite.com/personal/backup/#priceplans",
+    pricing: "custom",
     general: {
       releaseYear: { text: "2006" },
       folderBackups: { supported: true },
@@ -305,6 +309,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
     name: "CrashPlan",
     website: "https://crashplan.com",
     pricingUrl: "https://smb.crashplan.com/smb-pricing/",
+    pricing: "custom",
     general: {
       releaseYear: { text: "2007" },
       folderBackups: { supported: true },
@@ -344,6 +349,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
     name: "Acronis True Image",
     website: "https://www.acronis.com/en/products/true-image/",
     pricingUrl: "https://www.acronis.com/en/products/true-image/purchasing/",
+    pricing: "custom",
     general: {
       releaseYear: { text: "2003" },
       folderBackups: { supported: true },
@@ -382,6 +388,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
     name: "IDrive",
     website: "https://www.idrive.com",
     pricingUrl: "https://www.idrive.com/pricing",
+    pricing: "custom",
     general: {
       releaseYear: { text: "1995" },
       folderBackups: { supported: true },
@@ -420,6 +427,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
     name: "EaseUS Todo Backup",
     website: "https://www.easeus.com/backup-software/",
     pricingUrl: "https://www.easeus.com/store/backup.html",
+    pricing: "custom",
     general: {
       releaseYear: { text: "2009" },
       folderBackups: { supported: true },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add Free and Freemium pricing cards to the comparison page and auto-select a calculator based on each tool’s pricing type. This removes `hasCalculator` checks and shows a simple card when no custom calculator exists.

- **New Features**
  - Added `FreePricingCalculator` and `FreemiumPricingCalculator`.
  - `PricingCalculator` now resolves by slug first, then by `pricing` type (`free`, `freemium`, `custom`).
  - Always renders `PricingCalculator` in the grid; it returns null if none applies.

- **Migration**
  - `BackupTool` now requires `pricing`: set to `free`, `freemium`, or `custom` for each tool.

<sup>Written for commit 71966f0dd107947d7ea9b731b0287c714961c5a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

