### PR TITLE
feat(marketing): add kopia to comparison

### DIFF
--- a/libs/constants/src/comparison.ts
+++ b/libs/constants/src/comparison.ts
@@ -461,4 +461,42 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       rclone: { supported: false },
     },
   },
+  {
+    slug: "kopia",
+    name: "Kopia",
+    website: "https://kopia.io",
+    pricing: "free",
+    general: {
+      releaseYear: { text: "2019" },
+      folderBackups: { supported: true },
+      imageBackups: { supported: false },
+      openSource: { supported: true },
+    },
+    features: {
+      deduplication: { supported: true },
+      compression: { supported: true },
+      versioning: { supported: true },
+      scheduling: { supported: true },
+    },
+    privacy: {
+      endToEndEncryption: { supported: true },
+      zeroKnowledge: { supported: true },
+    },
+    platforms: {
+      windows: { supported: true },
+      macos: { supported: true },
+      linux: { supported: true },
+      android: { supported: false },
+      ios: { supported: false },
+    },
+    storages: {
+      managedCloud: { supported: false },
+      localFilesystem: { supported: true },
+      nas: { supported: true },
+      s3Compatible: { supported: true },
+      sftp: { supported: true },
+      webdav: { supported: true },
+      rclone: { supported: "partial", note: "Experimental" },
+    },
+  },
 ];


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Kopia to the backup tools comparison to broaden coverage on the marketing site. Includes features (deduplication, compression, versioning, scheduling), privacy (E2EE, zero-knowledge), desktop OS support (Windows, macOS, Linux), and storage options (local, NAS, S3, SFTP, WebDAV, experimental `rclone`).

<sup>Written for commit 7bb2f2204e24cf736552af215d56cd53c093de77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

