### PR TITLE
ci(marketing): remove daily site deployment

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -5,13 +5,11 @@ on:
     workflows: ["Deploy Desktop"]
     types:
       - completed
-  schedule:
-    - cron: "0 6 * * *"
   workflow_dispatch:
 
 jobs:
   deploy:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the daily cron from the marketing deploy workflow. The site now deploys only on manual dispatch or after a successful `Deploy Desktop` run.

<sup>Written for commit 7e26f318e9744353be75015ace9b1d0e2fc0be49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

