### PR TITLE
feat(marketing): show country in comparison

### DIFF
--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -32,6 +32,7 @@
     "@tailwindcss/vite": "^4.1.14",
     "astro": "^5.17.1",
     "astro-mermaid": "^1.3.1",
+    "country-flag-emoji-polyfill": "^0.1.8",
     "dom-to-image": "^2.6.0",
     "js-confetti": "^0.13.1",
     "jszip": "^3.10.1",

--- a/apps/marketing/src/layouts/BaseLayout.astro
+++ b/apps/marketing/src/layouts/BaseLayout.astro
@@ -120,6 +120,12 @@ const allStructuredData = [
 
     <ThemeScript />
 
+    <!-- Country flag emoji polyfill (Windows doesn't ship color flag glyphs) -->
+    <script>
+      import { polyfillCountryFlagEmojis } from "country-flag-emoji-polyfill";
+      polyfillCountryFlagEmojis();
+    </script>
+
     <!-- Endorsely -->
     {endorselyKey && (
       <script is:inline src="https://assets.endorsely.com/endorsely.js" data-endorsely={endorselyKey} async></script>

--- a/apps/marketing/src/styles.css
+++ b/apps/marketing/src/styles.css
@@ -85,7 +85,8 @@ body {
 }
 
 :root {
-  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  font-family:
+    "Twemoji Country Flags", Inter, ui-sans-serif, system-ui, sans-serif;
 }
 
 @keyframes marquee {

--- a/libs/constants/src/comparison.ts
+++ b/libs/constants/src/comparison.ts
@@ -25,6 +25,7 @@ export type BackupTool = {
     imageBackups: CellValue;
     openSource: CellValue;
     releaseYear: CellValue;
+    originCountry: CellValue;
   };
   features: {
     deduplication: CellValue;
@@ -77,6 +78,7 @@ export const COMPARISON_GENERAL_LABELS: Record<
     srText: { true: "Yes", false: "No", partial: "Partially" },
   },
   releaseYear: { text: "Release Year" },
+  originCountry: { text: "Country of Origin" },
 };
 
 export const COMPARISON_FEATURE_LABELS: Record<
@@ -201,6 +203,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: false },
       openSource: { supported: true },
+      originCountry: { text: "🇦🇹 Austria" },
     },
     features: {
       deduplication: { supported: true },
@@ -240,6 +243,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: false },
       openSource: { supported: false },
+      originCountry: { text: "🇺🇸 United States" },
     },
     features: {
       deduplication: { supported: true },
@@ -282,6 +286,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: false },
       openSource: { supported: false },
+      originCountry: { text: "🇺🇸 United States" },
     },
     features: {
       deduplication: { supported: true },
@@ -321,6 +326,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: false },
       openSource: { supported: false },
+      originCountry: { text: "🇺🇸 United States" },
     },
     features: {
       deduplication: { supported: true },
@@ -361,6 +367,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: true },
       openSource: { supported: false },
+      originCountry: { text: "🇨🇭 Switzerland" },
     },
     features: {
       deduplication: { supported: true },
@@ -400,6 +407,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: "partial", note: "Via IDrive Mirror" },
       openSource: { supported: false },
+      originCountry: { text: "🇺🇸 United States" },
     },
     features: {
       deduplication: null,
@@ -443,6 +451,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
         supported: "partial",
         note: "CLI source-available, GUI proprietary",
       },
+      originCountry: { text: "🇺🇸 United States" },
     },
     features: {
       deduplication: { supported: true },
@@ -482,6 +491,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: true },
       openSource: { supported: false },
+      originCountry: { text: "🇨🇳 China" },
     },
     features: {
       deduplication: null,
@@ -521,6 +531,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: "partial", note: "Windows & Linux" },
       openSource: { supported: false },
+      originCountry: { text: "🇺🇸 United States", note: "HQ moved from Switzerland in 2020" },
     },
     features: {
       deduplication: { supported: true },
@@ -562,6 +573,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: false },
       imageBackups: { supported: true },
       openSource: { supported: false },
+      originCountry: { text: "🇬🇧 United Kingdom" },
     },
     features: {
       deduplication: null,
@@ -602,6 +614,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: "partial", note: "Paid only" },
       openSource: { supported: false },
+      originCountry: { text: "🇮🇹 Italy" },
     },
     features: {
       deduplication: null,
@@ -642,6 +655,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: true },
       openSource: { supported: false },
+      originCountry: { text: "🇨🇳 China" },
     },
     features: {
       deduplication: null,
@@ -681,6 +695,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: true },
       openSource: { supported: false },
+      originCountry: { text: "🇩🇪 Germany" },
     },
     features: {
       deduplication: null,
@@ -719,6 +734,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: false },
       openSource: { supported: true },
+      originCountry: null,
     },
     features: {
       deduplication: { supported: true },
@@ -758,6 +774,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: false },
       openSource: { supported: true },
+      originCountry: { text: "🇩🇪 Germany" },
     },
     features: {
       deduplication: { supported: true },
@@ -797,6 +814,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: false },
       openSource: { supported: true },
+      originCountry: { text: "🇩🇰 Denmark" },
     },
     features: {
       deduplication: { supported: true },
@@ -836,6 +854,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: true },
       openSource: { supported: false },
+      originCountry: { text: "🇺🇸 United States" },
     },
     features: {
       deduplication: { supported: true },
@@ -875,6 +894,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: true },
       openSource: { supported: true },
+      originCountry: { text: "🇩🇪 Germany" },
     },
     features: {
       deduplication: { supported: true },
@@ -914,6 +934,7 @@ export const COMPARISON_TOOLS: BackupTool[] = [
       folderBackups: { supported: true },
       imageBackups: { supported: false },
       openSource: { supported: true },
+      originCountry: { text: "🇫🇷 France" },
     },
     features: {
       deduplication: { supported: true },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ importers:
       astro-mermaid:
         specifier: ^1.3.1
         version: 1.3.1(astro@5.17.1)(mermaid@11.12.2)
+      country-flag-emoji-polyfill:
+        specifier: ^0.1.8
+        version: 0.1.8
       dom-to-image:
         specifier: ^2.6.0
         version: 2.6.0
@@ -10971,6 +10974,10 @@ packages:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
     dependencies:
       layout-base: 2.0.1
+    dev: false
+
+  /country-flag-emoji-polyfill@0.1.8:
+    resolution: {integrity: sha512-Mbah52sADS3gshUYhK5142gtUuJpHYOXlXtLFI3Ly4RqgkmPMvhX9kMZSTqDM8P7UqtSW99eHKFphhQSGXA3Cg==}
     dev: false
 
   /crc-32@1.2.2:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a “Country of Origin” column to the backup tools comparison so visitors can see where each product comes from.

- **New Features**
  - Added `originCountry` to the comparison schema and labels (“Country of Origin”).
  - Populated country data (flag + name) for most tools; supports null when unknown.

- **Dependencies**
  - Added `country-flag-emoji-polyfill` and initialized it in `BaseLayout.astro`.
  - Added “Twemoji Country Flags” to the global font stack to ensure flags render on Windows.

<sup>Written for commit 3e19e2254ca3c2a9ba6f141ced985139d60284e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

