### PR TITLE
refactor(marketing): improvements to comparison pages

### DIFF
--- a/apps/marketing/src/components/compare/ComparisonPageContent.astro
+++ b/apps/marketing/src/components/compare/ComparisonPageContent.astro
@@ -136,7 +136,7 @@ const toolGridColumnCount = Math.max(
   tools.length + (hasAvailableTools ? 1 : 0),
   1,
 );
-const pricingGridColumnCount = Math.max(tools.length, 1);
+const pricingGridColumnCount = Math.max(tools.length, tools.length === 1 ? 2 : 1);
 const comparisonTableMinWidth =
   comparisonLabelColumnMinWidth +
   paddedTools.length * comparisonToolColumnMinWidth;
@@ -160,12 +160,8 @@ const comparisonPageMinWidth = useWideComparisonLayout
 const comparisonPageStyle = comparisonPageMinWidth
   ? `--comparison-page-min-width: ${comparisonPageMinWidth};`
   : undefined;
-const toolGridStyle = useWideComparisonLayout
-  ? `grid-template-columns: repeat(${toolGridColumnCount}, minmax(${comparisonCardMinWidth}px, 1fr));`
-  : undefined;
-const pricingGridStyle = useWideComparisonLayout
-  ? `grid-template-columns: repeat(${pricingGridColumnCount}, minmax(${comparisonCardMinWidth}px, 1fr));`
-  : undefined;
+const toolGridStyle = `grid-template-columns: repeat(${toolGridColumnCount}, minmax(${comparisonCardMinWidth}px, 1fr)); min-width: ${toolGridMinWidth}px;`;
+const pricingGridStyle = `grid-template-columns: repeat(${pricingGridColumnCount}, minmax(${comparisonCardMinWidth}px, 1fr)); min-width: ${pricingGridMinWidth}px;`;
 ---
 
 <article
@@ -187,65 +183,60 @@ const pricingGridStyle = useWideComparisonLayout
     </p>
   </header>
 
-  <div
-    class:list={[
-      "mb-10 grid gap-4",
-      !useWideComparisonLayout &&
-        "grid-cols-1 md:[grid-template-columns:repeat(auto-fit,minmax(260px,1fr))]",
-    ]}
-    style={toolGridStyle}
-  >
-    {
-      tools.map((tool, index) => (
-        <div class="text-center">
-          <div class="mb-3">
-            <ToolSelector
+  <div class="mb-10 overflow-x-auto overscroll-x-contain [-webkit-overflow-scrolling:touch]">
+    <div class="grid gap-4" style={toolGridStyle}>
+      {
+        tools.map((tool, index) => (
+          <div class="text-center">
+            <div class="mb-3">
+              <ToolSelector
+                client:load
+                tools={toolOptions}
+                selectedSlugs={selectedSlugs}
+                index={index}
+                showRemove={true}
+              />
+            </div>
+            <button
+              type="button"
+              class="w-full md:cursor-zoom-in"
+              data-lightbox-trigger
+              data-src={`https://static.blinkdisk.com/compare/screenshots/${tool.slug}.jpg`}
+              data-alt={`${tool.name} screenshot`}
+            >
+              <img
+                src={`https://static.blinkdisk.com/compare/screenshots/${tool.slug}.jpg`}
+                alt={`${tool.name} screenshot`}
+                class="aspect-[10/7] w-full rounded-lg border object-cover object-top"
+              />
+            </button>
+            <div class="mt-3">
+              <Button
+                href={tool.website}
+                target="_blank"
+                rel="noopener noreferrer"
+                size="lg"
+                class="w-full"
+              >
+                <ExternalLinkIcon class="size-4" />
+                {tool.name}
+              </Button>
+            </div>
+          </div>
+        ))
+      }
+      {
+        hasAvailableTools && (
+          <div class="text-center">
+            <AddToolButton
               client:load
               tools={toolOptions}
               selectedSlugs={selectedSlugs}
-              index={index}
-              showRemove={true}
             />
           </div>
-          <button
-            type="button"
-            class="w-full md:cursor-zoom-in"
-            data-lightbox-trigger
-            data-src={`https://static.blinkdisk.com/compare/screenshots/${tool.slug}.jpg`}
-            data-alt={`${tool.name} screenshot`}
-          >
-            <img
-              src={`https://static.blinkdisk.com/compare/screenshots/${tool.slug}.jpg`}
-              alt={`${tool.name} screenshot`}
-              class="aspect-[10/7] w-full rounded-lg border object-cover object-top"
-            />
-          </button>
-          <div class="mt-3">
-            <Button
-              href={tool.website}
-              target="_blank"
-              rel="noopener noreferrer"
-              size="lg"
-              class="w-full"
-            >
-              <ExternalLinkIcon class="size-4" />
-              {tool.name}
-            </Button>
-          </div>
-        </div>
-      ))
-    }
-    {
-      hasAvailableTools && (
-        <div class="text-center">
-          <AddToolButton
-            client:load
-            tools={toolOptions}
-            selectedSlugs={selectedSlugs}
-          />
-        </div>
-      )
-    }
+        )
+      }
+    </div>
   </div>
 
   <div
@@ -284,11 +275,13 @@ const pricingGridStyle = useWideComparisonLayout
                 {section.description}
               </p>
               <div class="bg-card overflow-hidden rounded-lg border">
-                <ComparisonTable
-                  tools={paddedTools}
-                  category={section.category}
-                  labels={section.labels}
-                />
+                <div class="overflow-x-auto overscroll-x-contain [-webkit-overflow-scrolling:touch]">
+                  <ComparisonTable
+                    tools={paddedTools}
+                    category={section.category}
+                    labels={section.labels}
+                  />
+                </div>
               </div>
             </>
           );
@@ -300,46 +293,41 @@ const pricingGridStyle = useWideComparisonLayout
         <p class="text-muted-foreground -mt-4 mb-6">
           Simple and transparent pricing calculators.
         </p>
-        <div
-          class:list={[
-            "grid gap-6",
-            !useWideComparisonLayout &&
-              "grid-cols-1 md:[grid-template-columns:repeat(auto-fit,minmax(260px,1fr))]",
-          ]}
-          style={pricingGridStyle}
-        >
-          {tools.map((tool) => (
-            <div class="flex flex-col gap-4">
-              <h4 class="text-center text-sm font-semibold">{tool.name}</h4>
-              <PricingCalculator client:load tool={tool} />
-              {tool.pricingUrl && (
-                <Button
-                  href={tool.pricingUrl}
-                  target={
-                    tool.pricingUrl.startsWith("http") ? "_blank" : undefined
-                  }
-                  rel={
-                    tool.pricingUrl.startsWith("http")
-                      ? "noopener noreferrer"
-                      : undefined
-                  }
-                  variant="secondary"
-                  class="w-full"
-                >
-                  <ExternalLinkIcon class="size-4" />
-                  View Pricing
-                </Button>
-              )}
-            </div>
-          ))}
-          {tools.length === 1 && (
-            <div
-              aria-hidden="true"
-              class="border-muted-foreground/20 text-muted-foreground from-muted/25 to-muted/10 hidden items-center justify-center rounded-lg border border-dashed bg-gradient-to-b text-sm font-medium md:flex"
-            >
-              No data
-            </div>
-          )}
+        <div class="overflow-x-auto overscroll-x-contain [-webkit-overflow-scrolling:touch]">
+          <div class="grid gap-6" style={pricingGridStyle}>
+            {tools.map((tool) => (
+              <div class="flex flex-col gap-4">
+                <h4 class="text-center text-sm font-semibold">{tool.name}</h4>
+                <PricingCalculator client:load tool={tool} />
+                {tool.pricingUrl && (
+                  <Button
+                    href={tool.pricingUrl}
+                    target={
+                      tool.pricingUrl.startsWith("http") ? "_blank" : undefined
+                    }
+                    rel={
+                      tool.pricingUrl.startsWith("http")
+                        ? "noopener noreferrer"
+                        : undefined
+                    }
+                    variant="secondary"
+                    class="w-full"
+                  >
+                    <ExternalLinkIcon class="size-4" />
+                    View Pricing
+                  </Button>
+                )}
+              </div>
+            ))}
+            {tools.length === 1 && (
+              <div
+                aria-hidden="true"
+                class="border-muted-foreground/20 text-muted-foreground from-muted/25 to-muted/10 flex items-center justify-center rounded-lg border border-dashed bg-gradient-to-b text-sm font-medium"
+              >
+                No data
+              </div>
+            )}
+          </div>
         </div>
 
         {tableSections.slice(2).map((section) => {
@@ -353,11 +341,13 @@ const pricingGridStyle = useWideComparisonLayout
                 {section.description}
               </p>
               <div class="bg-card overflow-hidden rounded-lg border">
-                <ComparisonTable
-                  tools={paddedTools}
-                  category={section.category}
-                  labels={section.labels}
-                />
+                <div class="overflow-x-auto overscroll-x-contain [-webkit-overflow-scrolling:touch]">
+                  <ComparisonTable
+                    tools={paddedTools}
+                    category={section.category}
+                    labels={section.labels}
+                  />
+                </div>
               </div>
             </>
           );

--- a/apps/marketing/src/components/compare/react/BlinkDiskPricingCalculator.tsx
+++ b/apps/marketing/src/components/compare/react/BlinkDiskPricingCalculator.tsx
@@ -9,6 +9,7 @@ import {
   SelectValue,
 } from "@blinkdisk/ui/select";
 import { Tabs, TabsList, TabsTrigger } from "@blinkdisk/ui/tabs";
+import FreePricingCalculator from "@marketing/components/compare/react/FreePricingCalculator";
 import { useMemo, useState } from "react";
 
 const currency = "USD";
@@ -49,13 +50,7 @@ export default function BlinkDiskPricingCalculator() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="border-primary/30 bg-primary/5 rounded-xl border-2 border-dashed p-4">
-        <p className="text-primary text-sm font-medium">Custom Storage</p>
-        <p className="mt-1 text-3xl font-bold">100% Free</p>
-        <p className="text-muted-foreground mt-1 text-xs">
-          Use your own S3, Backblaze B2, SFTP, etc.
-        </p>
-      </div>
+      <FreePricingCalculator />
 
       <div className="flex w-full items-center gap-4">
         <hr className="w-full border-t" />
@@ -66,7 +61,7 @@ export default function BlinkDiskPricingCalculator() {
       <div className="bg-card rounded-xl border p-4">
         <p className="text-lg font-semibold">CloudBlink</p>
         <p className="text-muted-foreground text-sm">
-          Our managed cloud storage service
+          Our optional cloud storage service
         </p>
 
         <Select

--- a/apps/marketing/src/layouts/DefaultLayout.astro
+++ b/apps/marketing/src/layouts/DefaultLayout.astro
@@ -9,9 +9,7 @@ const props = Astro.props as LayoutProps;
 
 <BaseLayout {...props}>
   <Navigation />
-  <main
-    class:list={[{ "overflow-x-auto": props.bodyClass === "comparison-page" }]}
-  >
+  <main>
     <slot />
   </main>
   <Footer />

--- a/apps/marketing/src/pages/compare/[slug].astro
+++ b/apps/marketing/src/pages/compare/[slug].astro
@@ -61,7 +61,6 @@ const structuredData = {
   title={title}
   description={description}
   structuredData={structuredData}
-  bodyClass="comparison-page"
 >
   <ComparisonPageContent
     tools={tools}

--- a/apps/marketing/src/pages/compare/index.astro
+++ b/apps/marketing/src/pages/compare/index.astro
@@ -18,7 +18,6 @@ const structuredData = {
   title={title}
   description={description}
   structuredData={structuredData}
-  bodyClass="comparison-page"
 >
   <ComparisonPageContent tools={[]} title={title} description={description} />
 </DefaultLayout>

--- a/apps/marketing/src/styles.css
+++ b/apps/marketing/src/styles.css
@@ -182,9 +182,14 @@ body:has([class~="sticky"], [class*=":sticky"]) {
 }
 
 .compare-page--wide {
-  width: max(
-    min(90vw, 64rem),
-    calc(var(--comparison-page-min-width) + var(--comparison-page-padding) * 2)
+  width: min(
+    90vw,
+    max(
+      64rem,
+      calc(
+        var(--comparison-page-min-width) + var(--comparison-page-padding) * 2
+      )
+    )
   );
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactors comparison pages to fix horizontal overflow and improve responsive layout. Adds scrollable grids/tables with min-widths, ensures consistent pricing layout with a single tool, and reuses `FreePricingCalculator`.

- **Refactors**
  - Always apply grid templates and min-widths for tool/pricing grids; wrap tool cards, comparison tables, and pricing calculators in horizontal scroll containers.
  - Set `pricingGridColumnCount` to 2 when only one tool; show the “No data” tile on all breakpoints.
  - Remove layout-level `overflow-x` and `bodyClass`; overflow is now scoped to comparison components.
  - Update `.compare-page--wide` to cap width at 90vw while respecting computed minimums.
  - Replace inline free-storage banner with `FreePricingCalculator`; copy updated to “optional cloud storage service.”

<sup>Written for commit 9c815a42f74612ce2fe7095ffb4bd0c1ddf87fb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

