### PR TITLE
feat(marketing): test download button texts

### DIFF
--- a/apps/marketing/src/components/CTA.astro
+++ b/apps/marketing/src/components/CTA.astro
@@ -41,7 +41,9 @@ const {
   </p>
 
   <div class="flex flex-row items-center justify-center gap-4">
-    <Button href="/download" size="lg"> Download for free </Button>
+    <Button href="/download" size="lg">
+      <span data-download-button>Download App</span>
+    </Button>
     <Button
       href={secondaryButtonHref}
       size="lg"

--- a/apps/marketing/src/layouts/BaseLayout.astro
+++ b/apps/marketing/src/layouts/BaseLayout.astro
@@ -144,6 +144,14 @@ const allStructuredData = [
             ui_host: "https://eu.posthog.com",
             defaults: '2025-11-30',
         })
+        posthog.onFeatureFlags(function () {
+          var text = posthog.getFeatureFlag('download-button') === 'download-for-free'
+            ? 'Download for free'
+            : 'Download App';
+          document.querySelectorAll('[data-download-button]').forEach(function (el) {
+            el.textContent = text;
+          });
+        });
       </script>
     )}
 

--- a/apps/marketing/src/sections/Hero.astro
+++ b/apps/marketing/src/sections/Hero.astro
@@ -40,7 +40,7 @@ import XIcon from "@lucide/astro/icons/x";
       </Button>
       <Button href="/download">
         <DownloadIcon class="mr-1.5 size-4 md:size-5" />
-        Download for free
+        <span data-download-button>Download App</span>
       </Button>
     </div>
     <div class="mt-12 hidden items-center gap-3 sm:flex">
@@ -56,7 +56,7 @@ import XIcon from "@lucide/astro/icons/x";
       </Button>
       <Button size="xl" href="/download">
         <DownloadIcon class="mr-1.5 size-4 md:size-5" />
-        Download for free
+        <span data-download-button>Download App</span>
       </Button>
     </div>
   </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a PostHog feature flag experiment to A/B test the download button copy across the marketing site, switching between “Download App” and “Download for free” without changing URLs.

- **New Features**
  - Uses `posthog` feature flag `download-button` to choose between “Download for free” (variant `download-for-free`) and “Download App”.
  - Replaced static button text with `<span data-download-button>` in CTA and Hero; a script in `BaseLayout.astro` updates all matching elements when flags load.

<sup>Written for commit 0bb90bab0815c0c3731b9358d253006d77094dda. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

