### PR TITLE
feat(marketing): add cta to landing page

### DIFF
--- a/apps/marketing/src/components/CTA.astro
+++ b/apps/marketing/src/components/CTA.astro
@@ -1,21 +1,33 @@
 ---
 import Button from "@marketing/components/Button.astro";
 
+type Size = "sm" | "lg";
+
 type Props = {
   headline?: string;
   secondaryButtonText?: string;
   secondaryButtonHref?: string;
+  size?: Size;
 };
 
 const {
   headline,
   secondaryButtonText = "Read more",
   secondaryButtonHref = "/",
+  size = "lg",
 } = Astro.props;
+
+const sizeClasses: Record<Size, string> = {
+  sm: "w-[90vw] max-w-3xl lg:max-w-4xl",
+  lg: "w-content",
+};
 ---
 
 <section
-  class="cta-pattern bg-secondary relative mt-16 overflow-hidden rounded-2xl border px-8 py-12 text-center md:px-12 md:py-16"
+  class:list={[
+    "cta-pattern bg-secondary relative mx-auto mt-16 overflow-hidden rounded-2xl border px-8 py-12 text-center md:px-12 md:py-16",
+    sizeClasses[size],
+  ]}
 >
   <div class="mb-6 flex items-center justify-center gap-4">
     <div class="bg-foreground/20 h-px w-8"></div>

--- a/apps/marketing/src/layouts/BlogPostLayout.astro
+++ b/apps/marketing/src/layouts/BlogPostLayout.astro
@@ -107,6 +107,6 @@ const blogPostingSchema = {
       </aside>
     </div>
 
-    <CTA headline={ctaHeadline} />
+    <CTA size="sm" headline={ctaHeadline} />
   </article>
 </DefaultLayout>

--- a/apps/marketing/src/layouts/GlossaryTermLayout.astro
+++ b/apps/marketing/src/layouts/GlossaryTermLayout.astro
@@ -85,6 +85,6 @@ const structuredData = getCombinedStructuredData(termData, summary, siteUrl);
 
     <RelatedTerms terms={relatedTerms} />
 
-    <CTA />
+    <CTA size="sm" />
   </article>
 </DefaultLayout>

--- a/apps/marketing/src/pages/cloudblink.astro
+++ b/apps/marketing/src/pages/cloudblink.astro
@@ -721,7 +721,7 @@ const productSchema = {
     </div>
   </section>
 
-  <div class="w-content mx-auto pb-20">
+  <div class="pb-20">
     <CTA
       headline={"Try CloudBlink for free\nNo credit card required"}
       secondaryButtonText="View plans"

--- a/apps/marketing/src/pages/index.astro
+++ b/apps/marketing/src/pages/index.astro
@@ -9,6 +9,7 @@ import Downloads from "@marketing/sections/Downloads.astro";
 import Storages from "@marketing/sections/Storages.astro";
 import OpenSource from "@marketing/sections/OpenSource.astro";
 import Faq from "@marketing/sections/Faq.astro";
+import CTA from "@marketing/components/CTA.astro";
 import { getFaqStructuredData } from "@marketing/data/faqs";
 import { MARKETING_URL } from "astro:env/server";
 
@@ -66,4 +67,7 @@ const structuredData = [getFaqStructuredData(), softwareSchema];
   <Storages />
   <OpenSource />
   <Faq />
+  <div class="pb-page">
+    <CTA />
+  </div>
 </DefaultLayout>

--- a/apps/marketing/src/sections/Faq.astro
+++ b/apps/marketing/src/sections/Faq.astro
@@ -3,7 +3,7 @@ import { faqs } from "@marketing/data/faqs";
 import FaqList from "@marketing/components/FaqList.astro";
 ---
 
-<section id="faqs" class="mx-auto pb-32 pt-16 sm:pb-40 sm:pt-24">
+<section id="faqs" class="mx-auto pb-16 pt-16 sm:pb-24 sm:pt-24">
   <div class="w-content mx-auto flex flex-col items-center text-center">
     <h2 class="text-center text-4xl font-bold sm:text-5xl">
       Questions & Answers


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a call-to-action to the landing page and makes the `CTA` component size-configurable to fit different layouts. Improves layout consistency by centralizing CTA width handling.

- **New Features**
  - Added `<CTA />` to the landing page.
  - Introduced `size` prop to `CTA` (`sm` | `lg`, default `lg`) with width presets and centered layout.
  - Applied `size="sm"` in blog and glossary pages; tightened FAQ spacing and removed redundant container on CloudBlink page to rely on `CTA` sizing.

<sup>Written for commit 7a137767012706602d5a7ba3edf3f61c9dcd300b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

