### PR TITLE
refactor(marketing): landing design improvements

### DIFF
--- a/apps/marketing/src/components/react/DownloadButton.tsx
+++ b/apps/marketing/src/components/react/DownloadButton.tsx
@@ -5,9 +5,10 @@ import { useEffect, useState } from "react";
 
 type Props = {
   os: Platform;
+  className?: string;
 };
 
-export function DownloadButton({ os }: Props) {
+export function DownloadButton({ os, className }: Props) {
   const { platform } = usePlatform();
   const [mounted, setMounted] = useState(false);
 
@@ -21,6 +22,7 @@ export function DownloadButton({ os }: Props) {
     <Button
       variant={isCurrentPlatform ? "default" : "outline"}
       render={<a href="/download" />}
+      className={className}
     >
       Download
     </Button>

--- a/apps/marketing/src/components/react/animations/EncryptionAnimation.tsx
+++ b/apps/marketing/src/components/react/animations/EncryptionAnimation.tsx
@@ -105,10 +105,7 @@ export default function EncryptionAnimation() {
         </div>
       </div>
       <hr className="w-full border-t" />
-      <p
-        className="whitespace-pre text-base/7"
-        style={{ fontFamily: "'Space Mono', monospace" }}
-      >
+      <p className="whitespace-pre font-mono text-base/7">
         <span className="text-muted-foreground">{encryptedText}</span>
         {encryptedText.length !== originalText.length &&
         encryptedText.length !== 0 ? (

--- a/apps/marketing/src/components/react/code/result.tsx
+++ b/apps/marketing/src/components/react/code/result.tsx
@@ -328,12 +328,7 @@ function Stat({ icon, title, description, value, className }: StatProps) {
       <p className="text-lg leading-none tracking-tight [&>svg]:mr-1 [&>svg]:inline-block [&>svg]:size-4">
         {icon} {title}
       </p>
-      <p
-        style={{
-          fontFamily: "Space Mono, monospace",
-        }}
-        className="mt-2 text-4xl font-bold tracking-tighter"
-      >
+      <p className="mt-2 font-mono text-4xl font-bold tracking-tighter">
         {value}
       </p>
       {description && (

--- a/apps/marketing/src/sections/Downloads.astro
+++ b/apps/marketing/src/sections/Downloads.astro
@@ -3,40 +3,64 @@ import Windows from "@marketing/components/icons/Windows.astro";
 import Macos from "@marketing/components/icons/Macos.astro";
 import Linux from "@marketing/components/icons/Linux.astro";
 import { DownloadButton } from "@marketing/components/react/DownloadButton";
+import { getLatestReleaseVersion } from "@marketing/utils/github";
 import type { Platform } from "@marketing/utils/platform";
+
+const version = await getLatestReleaseVersion();
 
 const operatingSystems: {
   name: string;
   icon: string;
   platform: Platform;
   description: string;
+  arch: string;
 }[] = [
   {
     name: "Windows",
     icon: "windows",
     platform: "windows",
     description: "Windows 11 and Windows 10 with 64-bit supported.",
+    arch: "x64 · ARM64",
   },
   {
     name: "macOS",
     icon: "macos",
     platform: "macos",
     description: "Big Sur and all newer versions of macOS are supported.",
+    arch: "Intel · Apple Silicon",
   },
   {
     name: "Linux",
     icon: "linux",
     platform: "linux",
     description: "AppImage, deb, and rpm for x86_64, arm64 and armv7l.",
+    arch: "x86_64 · amd64 · ARM",
   },
 ];
 ---
 
 <section
   id="integrations"
-  class="w-content mx-auto flex flex-col items-center py-16 sm:py-24"
+  class="w-content relative mx-auto flex flex-col items-center py-16 sm:py-24"
 >
-  <h2 class="text-center text-4xl font-bold sm:text-5xl">
+  <!-- Mono kicker -->
+  <div
+    class="bg-card/70 inline-flex items-center gap-2.5 rounded-full border px-3.5 py-1.5 backdrop-blur-sm"
+  >
+    <span class="relative flex size-1.5">
+      <span class="bg-primary/60 absolute inset-0 animate-ping rounded-full"
+      ></span>
+      <span class="bg-primary relative inline-flex size-1.5 rounded-full"
+      ></span>
+    </span>
+    <span
+      class="text-muted-foreground downloads-mono text-[0.68rem] font-bold uppercase tracking-[0.18em]"
+    >
+      Cross-Platform
+    </span>
+  </div>
+
+  <h2 class="mt-6 text-center text-4xl font-bold sm:text-5xl">
     Backup from any device
   </h2>
   <p class="text-muted-foreground mt-4 text-center text-sm md:text-base">
@@ -44,23 +68,38 @@ const operatingSystems: {
     Linux.
   </p>
   <div
-    class="sm:mt-22 mt-16 grid w-full grid-cols-1 gap-10 sm:grid-cols-3 md:gap-0"
+    class="max-w-92 mt-16 grid w-full grid-cols-1 gap-6 sm:mt-20 sm:gap-5 md:max-w-full md:grid-cols-3"
   >
     {
       operatingSystems.map((os) => (
-        <div class="max-w-70 mx-auto flex w-full flex-col items-start sm:items-center [&>svg]:size-10">
-          <div class="flex flex-row items-center gap-4 sm:flex-col">
-            {os.icon === "windows" && <Windows class="size-10" />}
-            {os.icon === "macos" && <Macos class="size-10" />}
-            {os.icon === "linux" && <Linux class="size-10" />}
-            <p class="text-3xl font-bold">{os.name}</p>
+        <div class="bg-card group relative flex flex-col overflow-hidden rounded-2xl border p-6 transition-all">
+          <div class="relative flex items-center justify-between">
+            <div class="bg-muted/50 border-border/60 flex size-12 items-center justify-center rounded-xl border [&>svg]:size-6">
+              {os.icon === "windows" && <Windows />}
+              {os.icon === "macos" && <Macos />}
+              {os.icon === "linux" && <Linux />}
+            </div>
+            <span class="text-muted-foreground/60 font-mono text-sm font-bold">
+              {version}
+            </span>
           </div>
-          <p class="text-muted-foreground sm:max-w-50 mt-2 w-full text-sm sm:text-center">
+
+          <p class="mt-5 text-2xl font-bold sm:text-3xl">{os.name}</p>
+          <p class="text-muted-foreground mt-1.5 text-sm leading-relaxed">
             {os.description}
           </p>
-          <div class="mt-8">
-            <DownloadButton client:visible os={os.platform} />
+
+          <div class="border-border/60 my-7 flex items-center gap-2">
+            <span class="text-muted-foreground/70 font-mono text-[0.6rem] font-bold uppercase tracking-[0.16em]">
+              Architecture
+            </span>
+            <span class="bg-border/60 h-px flex-1" />
+            <span class="text-foreground/80 font-mono text-[0.62rem] font-semibold tracking-tight">
+              {os.arch}
+            </span>
           </div>
+
+          <DownloadButton className="w-full" client:visible os={os.platform} />
         </div>
       ))
     }

--- a/apps/marketing/src/sections/Faq.astro
+++ b/apps/marketing/src/sections/Faq.astro
@@ -8,11 +8,29 @@ import FaqList from "@marketing/components/FaqList.astro";
     <h2 class="text-center text-4xl font-bold sm:text-5xl">
       Questions & Answers
     </h2>
-    <p class="text-muted-foreground mt-4 text-center">
+    <p class="text-muted-foreground mt-4 text-center text-sm md:text-base">
       Still have questions? Here are answers to some frequently asked questions.
     </p>
   </div>
-  <div class="mt-6 sm:mt-16">
+
+  <div class="relative mt-10 sm:mt-16">
     <FaqList faqs={faqs} />
+  </div>
+
+  <!-- Bottom helper -->
+  <div class="w-content mx-auto mt-10 flex flex-col items-center sm:mt-14">
+    <span
+      class="text-muted-foreground/70 inline-flex items-center gap-2 font-mono text-[0.62rem] font-bold uppercase tracking-[0.18em] sm:text-[0.68rem]"
+    >
+      <span class="bg-border h-px w-8"></span>
+      Still curious?
+      <span class="bg-border h-px w-8"></span>
+    </span>
+    <p class="text-muted-foreground mt-3 text-sm">
+      Reach us at <a
+        href="mailto:hello@blinkdisk.com"
+        class="text-primary font-medium hover:underline">hi@blinkdisk.com</a
+      >
+    </p>
   </div>
 </section>

--- a/apps/marketing/src/sections/Faq.astro
+++ b/apps/marketing/src/sections/Faq.astro
@@ -28,7 +28,7 @@ import FaqList from "@marketing/components/FaqList.astro";
     </span>
     <p class="text-muted-foreground mt-3 text-sm">
       Reach us at <a
-        href="mailto:hello@blinkdisk.com"
+        href="mailto:hi@blinkdisk.com"
         class="text-primary font-medium hover:underline">hi@blinkdisk.com</a
       >
     </p>

--- a/apps/marketing/src/sections/Features.astro
+++ b/apps/marketing/src/sections/Features.astro
@@ -49,7 +49,7 @@ const features = [
             feature.flip ? "md:ml-20 xl:ml-32" : "md:mr-20 xl:mr-32",
           ]}
         >
-          <h2 class="text-primary text-xs font-semibold uppercase tracking-widest sm:text-sm sm:tracking-[0.2rem]">
+          <h2 class="text-primary font-mono text-xs font-semibold uppercase tracking-widest sm:text-sm sm:tracking-[0.2rem]">
             {feature.category}
           </h2>
           <p class="text-foreground mt-4 text-left text-[2rem] font-bold leading-[1.125] md:text-[2.7rem]">

--- a/apps/marketing/src/sections/Problems.astro
+++ b/apps/marketing/src/sections/Problems.astro
@@ -8,12 +8,26 @@ import InfoIcon from "@lucide/astro/icons/info";
   id="problems"
   class="w-content mx-auto flex flex-col items-center py-16 sm:py-32"
 >
-  <div class="flex items-center gap-5">
-    <TriangleAlertIcon class="hidden size-10 text-red-500 sm:block" />
-    <h2 class="text-center text-4xl font-bold sm:text-5xl">
-      Your files are at risk
-    </h2>
+  <!-- Mono kicker -->
+  <div
+    class="bg-card/70 inline-flex items-center gap-2.5 rounded-full border px-3.5 py-1.5 backdrop-blur-sm"
+  >
+    <span class="relative flex size-1.5">
+      <span class="absolute inset-0 animate-ping rounded-full bg-red-500/60"
+      ></span>
+      <span class="relative inline-flex size-1.5 rounded-full bg-red-500"
+      ></span>
+    </span>
+    <span
+      class="text-muted-foreground font-mono text-[0.68rem] font-bold uppercase tracking-[0.18em]"
+    >
+      Why it matters
+    </span>
   </div>
+
+  <h2 class="mt-6 text-center text-4xl font-bold sm:text-5xl">
+    Your files are at risk
+  </h2>
   <p
     class="sm:w-150 text-muted-foreground mt-4 w-full text-center text-sm md:text-base"
   >
@@ -21,13 +35,21 @@ import InfoIcon from "@lucide/astro/icons/info";
     illusion. Most people only keep one copy of their data, and one copy is
     never enough.
   </p>
+
   <div class="mt-18 grid w-full grid-cols-1 gap-16 xl:grid-cols-3 xl:gap-8">
     <!-- Problem 1 -->
     <div
       class="lg:gap-30 flex flex-col items-start gap-8 sm:flex-row sm:items-center sm:gap-10 md:gap-20 xl:flex-col xl:items-start xl:gap-8"
     >
       <div class="flex flex-col gap-2">
-        <h3 class="text-2xl font-bold sm:text-3xl">
+        <span
+          class="text-muted-foreground problems-mono inline-flex items-center gap-1.5 text-[0.65rem] font-bold uppercase tracking-[0.16em]"
+        >
+          <span class="text-red-500/70">01</span>
+          <span class="bg-muted-foreground/20 h-px w-6"></span>
+          Human Errors
+        </span>
+        <h3 class="mt-1 text-2xl font-bold sm:text-3xl">
           A wrong click and everything's gone
         </h3>
         <p class="text-muted-foreground mt-1 text-sm">
@@ -37,24 +59,36 @@ import InfoIcon from "@lucide/astro/icons/info";
         </p>
       </div>
       <div
-        class="max-w-90 relative mx-auto flex aspect-video w-full shrink-0 flex-col items-start justify-between rounded-xl border-2 border-red-500/10 bg-red-500/10 p-2 sm:w-80 md:m-0 dark:bg-red-500/5"
+        class="max-w-90 relative mx-auto flex aspect-video w-full shrink-0 flex-col items-start justify-between rounded-xl border-2 border-red-500/15 bg-red-500/10 p-2 sm:w-80 md:m-0 dark:bg-red-500/5"
       >
         <div
-          class="bg-card flex h-full w-full flex-col justify-between rounded-lg border p-5"
+          class="bg-card relative flex h-full w-full flex-col justify-between overflow-hidden rounded-lg border"
         >
-          <p class="font-medium">
-            Are you sure you want to permanently delete this folder?
-          </p>
-          <div class="mt-4 flex w-full justify-end gap-2">
-            <div
-              class="border-foreground/20 w-fit rounded-md border px-3 py-1.5 text-sm font-medium"
-            >
-              Cancel
-            </div>
-            <div
-              class="w-fit rounded-md bg-red-500 px-3 py-1.5 text-sm font-medium text-white"
-            >
-              Delete
+          <!-- Window chrome -->
+          <div
+            class="bg-muted/40 flex items-center gap-1.5 border-b px-3 py-1.5"
+          >
+            <span class="size-2 rounded-full bg-red-400/60"></span>
+            <span class="size-2 rounded-full bg-yellow-400/60"></span>
+            <span class="size-2 rounded-full bg-green-400/60"></span>
+          </div>
+          <div class="flex flex-1 flex-col justify-between p-4">
+            <p class="font-medium leading-tight">
+              Are you sure you want to permanently delete this folder?
+            </p>
+            <div class="mt-4 flex w-full items-center justify-end">
+              <div class="flex gap-2">
+                <div
+                  class="border-foreground/20 w-fit rounded-md border px-3 py-1.5 text-sm font-medium"
+                >
+                  Cancel
+                </div>
+                <div
+                  class="relative w-fit rounded-md bg-red-500 px-3 py-1.5 text-sm font-medium text-white"
+                >
+                  Delete
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -66,7 +100,14 @@ import InfoIcon from "@lucide/astro/icons/info";
       class="lg:gap-30 flex flex-col items-start gap-8 sm:flex-row sm:items-center sm:gap-10 md:gap-20 xl:flex-col xl:items-start xl:gap-8"
     >
       <div class="flex flex-col gap-2">
-        <h3 class="text-2xl font-bold sm:text-3xl">
+        <span
+          class="text-muted-foreground problems-mono inline-flex items-center gap-1.5 text-[0.65rem] font-bold uppercase tracking-[0.16em]"
+        >
+          <span class="text-red-500/70">02</span>
+          <span class="bg-muted-foreground/20 h-px w-6"></span>
+          Hardware Failures
+        </span>
+        <h3 class="mt-1 text-2xl font-bold sm:text-3xl">
           Every hard drive dies and yours will too
         </h3>
         <p class="text-muted-foreground mt-1 text-sm">
@@ -76,17 +117,27 @@ import InfoIcon from "@lucide/astro/icons/info";
         </p>
       </div>
       <div
-        class="max-w-90 relative mx-auto flex aspect-video w-full shrink-0 flex-col items-start justify-between rounded-xl border-2 border-red-500/10 bg-red-500/10 p-2 sm:w-80 md:m-0 dark:bg-red-500/5"
+        class="max-w-90 relative mx-auto flex aspect-video w-full shrink-0 flex-col items-start justify-between rounded-xl border-2 border-red-500/15 bg-red-500/10 p-2 sm:w-80 md:m-0 dark:bg-red-500/5"
       >
         <div
-          class="bg-card flex h-full w-full flex-col justify-between rounded-lg border p-5"
+          class="bg-card relative flex h-full w-full flex-col overflow-hidden rounded-lg border"
         >
-          <div class="my-auto flex w-full flex-col items-center">
-            <TriangleAlertIcon class="mx-auto size-8 text-red-500" />
-            <p class="mt-3 text-center text-xl font-medium">
+          <!-- Window chrome -->
+          <div
+            class="bg-muted/40 flex items-center gap-1.5 border-b px-3 py-1.5"
+          >
+            <span class="size-2 rounded-full bg-red-400/60"></span>
+            <span class="size-2 rounded-full bg-yellow-400/60"></span>
+            <span class="size-2 rounded-full bg-green-400/60"></span>
+          </div>
+          <div class="flex flex-1 flex-col items-center justify-center p-4">
+            <TriangleAlertIcon class="size-8 text-red-500" />
+            <p class="mt-3 text-center text-xl font-medium leading-tight">
               Failed to start device
             </p>
-            <p class="text-muted-foreground mt-1 text-center text-xs">
+            <p
+              class="problems-mono text-muted-foreground mt-1.5 text-center text-[0.65rem] uppercase tracking-[0.14em]"
+            >
               Error: DISK_IS_CORRUPTED
             </p>
           </div>
@@ -99,7 +150,14 @@ import InfoIcon from "@lucide/astro/icons/info";
       class="lg:gap-30 flex flex-col items-start gap-8 sm:flex-row sm:items-center sm:gap-10 md:gap-20 xl:flex-col xl:items-start xl:gap-8"
     >
       <div class="flex flex-col gap-2">
-        <h3 class="text-2xl font-bold sm:text-3xl">
+        <span
+          class="text-muted-foreground problems-mono inline-flex items-center gap-1.5 text-[0.65rem] font-bold uppercase tracking-[0.16em]"
+        >
+          <span class="text-red-500/70">03</span>
+          <span class="bg-muted-foreground/20 h-px w-6"></span>
+          Cyber Attacks
+        </span>
+        <h3 class="mt-1 text-2xl font-bold sm:text-3xl">
           Hackers don't care about your files
         </h3>
         <p class="text-muted-foreground mt-1 text-sm">
@@ -109,17 +167,31 @@ import InfoIcon from "@lucide/astro/icons/info";
         </p>
       </div>
       <div
-        class="max-w-90 relative mx-auto flex aspect-video w-full shrink-0 flex-col items-start justify-between rounded-xl border-2 border-red-500/10 bg-red-500/10 p-2 sm:w-80 md:m-0 dark:bg-red-500/5"
+        class="max-w-90 relative mx-auto flex aspect-video w-full shrink-0 flex-col items-start justify-between rounded-xl border-2 border-red-500/15 bg-red-500/10 p-2 sm:w-80 md:m-0 dark:bg-red-500/5"
       >
         <div
-          class="bg-card flex h-full w-full flex-col justify-between rounded-lg border p-5"
+          class="bg-card relative flex h-full w-full flex-col overflow-hidden rounded-lg border"
         >
-          <LockIcon class="size-8 text-red-500" />
-          <div class="flex flex-col">
-            <p class="text-base font-medium">Your files have been encrypted!</p>
-            <p class="text-muted-foreground mt-1 text-xs">
-              Send us $1,000 worth of bitcoin to recover your files.
-            </p>
+          <!-- Window chrome -->
+          <div
+            class="bg-muted/40 flex items-center gap-1.5 border-b px-3 py-1.5"
+          >
+            <span class="size-2 rounded-full bg-red-400/60"></span>
+            <span class="size-2 rounded-full bg-yellow-400/60"></span>
+            <span class="size-2 rounded-full bg-green-400/60"></span>
+          </div>
+          <div class="flex flex-1 flex-col justify-between p-4">
+            <LockIcon class="size-7 text-red-500" />
+            <div class="flex flex-col">
+              <p class="text-base font-medium leading-tight">
+                Your files have been encrypted!
+              </p>
+              <p
+                class="text-muted-foreground problems-mono mt-1.5 text-xs tracking-tight"
+              >
+                Send us $1,000 in bitcoin to recover your files.
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/marketing/src/sections/Quote.astro
+++ b/apps/marketing/src/sections/Quote.astro
@@ -5,7 +5,7 @@ import simonImage from "@marketing/assets/images/simon.jpg";
 
 <section
   id="quote"
-  class="w-content mx-auto px-6 py-16 sm:px-0 sm:py-24 md:max-w-3xl"
+  class="w-content mx-auto px-6 py-20 sm:px-0 sm:py-32 md:max-w-3xl"
 >
   <figure class="w-full">
     <p class="sr-only">5 out of 5 stars</p>
@@ -34,8 +34,11 @@ import simonImage from "@marketing/assets/images/simon.jpg";
     >
       <p>
         "A few months ago, my hard drive suddenly died. Years of work, photos,
-        and memories were gone in an instant. If I had set up BlinkDisk before,
-        it would've taken five minutes to protect everything."
+        and memories were gone in an instant. <span
+          class="quote-highlight relative inline whitespace-normal"
+          >If I had set up BlinkDisk before, it would've taken five minutes to
+          protect everything.</span
+        >"
       </p>
     </blockquote>
     <figcaption class="mt-8 flex items-center gap-4">
@@ -50,8 +53,23 @@ import simonImage from "@marketing/assets/images/simon.jpg";
       />
       <div class="flex flex-col">
         <p class="text-lg font-semibold">Simon K.</p>
-        <p class="text-muted-foreground text-sm">BlinkDisk User</p>
+        <p class="text-muted-foreground text-xs">BlinkDisk User</p>
       </div>
     </figcaption>
   </figure>
 </section>
+
+<style>
+  .quote-highlight {
+    --highlight: color-mix(in srgb, var(--primary) 22%, transparent);
+    background-image: linear-gradient(
+      to bottom,
+      transparent 82%,
+      var(--highlight) 82%,
+      var(--highlight) 100%
+    );
+    background-repeat: no-repeat;
+    background-size: 100% 100%;
+    background-position: 0 0;
+  }
+</style>

--- a/apps/marketing/src/sections/Solution.astro
+++ b/apps/marketing/src/sections/Solution.astro
@@ -1,7 +1,6 @@
 ---
 import Folder from "@marketing/components/Folder.astro";
 import { EXAMPLE_FOLDERS } from "@blinkdisk/constants/folder";
-import LockIcon from "@lucide/astro/icons/lock";
 
 const steps = [
   {
@@ -24,15 +23,30 @@ const steps = [
 
 <section
   id="solution"
-  class="w-content mx-auto flex flex-col items-center py-16 sm:py-24"
+  class="w-content relative mx-auto flex flex-col items-center py-16 sm:py-24"
 >
-  <div class="flex items-center gap-5">
-    <LockIcon class="text-primary hidden size-10 md:block" />
-    <h2 class="text-center text-4xl font-bold sm:text-5xl">
-      Get protected in <br class="sm:hidden" />
-      <span class="sm:hidden">a few</span> minutes
-    </h2>
+  <!-- Mono kicker -->
+  <div
+    class="bg-card/70 inline-flex items-center gap-2.5 rounded-full border px-3.5 py-1.5 backdrop-blur-sm"
+  >
+    <span class="relative flex size-1.5">
+      <span class="bg-primary/60 absolute inset-0 animate-ping rounded-full"
+      ></span>
+      <span class="bg-primary relative inline-flex size-1.5 rounded-full"
+      ></span>
+    </span>
+    <span
+      class="text-muted-foreground font-mono text-[0.68rem] font-bold uppercase tracking-[0.18em]"
+    >
+      The Solution
+    </span>
   </div>
+
+  <h2 class="mt-6 text-center text-4xl font-bold sm:text-5xl">
+    Get protected in <br class="sm:hidden" />
+    <span class="sm:hidden">a few</span> minutes
+  </h2>
+
   <p
     class="md:w-160 text-muted-foreground mt-4 w-full text-center text-sm md:text-base"
   >
@@ -45,20 +59,20 @@ const steps = [
       steps.map(({ title, description }, index) => (
         <div class="flex w-full flex-row items-center gap-8 md:flex-col md:gap-0">
           <div class="flex h-full flex-col items-center md:h-auto md:w-full md:flex-row">
-            <hr
+            <div
               class:list={[
-                "border-primary/30 grow border-l-2 md:border-t-2",
+                "border-primary/30 grow border-l-2 border-dashed md:border-l-0 md:border-t-2",
                 index === 0 && "invisible",
               ]}
             />
-            <div class="bg-primary/10 border-primary/30 flex size-10 items-center justify-center rounded-lg border md:size-12">
-              <span class="text-primary whitespace-nowrap text-lg font-medium md:text-xl">
-                {index + 1}
+            <div class="bg-primary/10 border-primary/30 size-13 relative flex shrink-0 items-center justify-center rounded-xl border">
+              <span class="text-primary relative whitespace-nowrap font-mono text-base font-bold md:text-lg">
+                0{index + 1}
               </span>
             </div>
-            <hr
+            <div
               class:list={[
-                "border-primary/30 grow border-l-2 md:border-t-2",
+                "border-primary/30 grow border-l-2 border-dashed md:border-l-0 md:border-t-2",
                 index === steps.length - 1 && "invisible",
               ]}
             />
@@ -67,16 +81,29 @@ const steps = [
             <h3 class="text-xl font-semibold md:text-2xl md:font-bold">
               {title}
             </h3>
-            <p class="text-muted-foreground text-sm">{description}</p>
+            <p class="text-muted-foreground text-sm leading-relaxed">
+              {description}
+            </p>
           </div>
         </div>
       ))
     }
   </div>
 
+  <!-- Marquee header -->
+  <div class="mt-20 flex items-center gap-3 md:mt-28" aria-hidden="true">
+    <span class="bg-border h-px w-8 sm:w-12"></span>
+    <span
+      class="text-muted-foreground font-mono text-[0.62rem] font-bold uppercase tracking-[0.2em] sm:text-[0.68rem]"
+    >
+      ↓ Protect what matters most
+    </span>
+    <span class="bg-border h-px w-8 sm:w-12"></span>
+  </div>
+
   <!-- CSS Marquee -->
   <div
-    class="mt-18 w-full overflow-hidden md:mt-24"
+    class="mt-6 w-full overflow-hidden md:mt-8"
     style="mask-image: linear-gradient(to right, transparent, black 10%, black 90%, transparent);"
   >
     <div class="marquee flex w-max">

--- a/apps/marketing/src/sections/Storages.astro
+++ b/apps/marketing/src/sections/Storages.astro
@@ -70,11 +70,46 @@ const otherStorages = [
   },
 ];
 
-const allStorages = [...localStorages, ...cloudStorages, ...otherStorages];
+const categories = [
+  {
+    label: "Local",
+    count: "04",
+    storages: localStorages,
+  },
+  {
+    label: "Cloud",
+    count: "04",
+    storages: cloudStorages,
+  },
+  {
+    label: "Protocols",
+    count: "04+",
+    storages: otherStorages,
+  },
+];
 ---
 
-<section class="w-content mx-auto flex flex-col items-center py-16 sm:py-24">
-  <h2 class="text-center text-4xl font-bold sm:text-5xl">
+<section
+  class="w-content relative mx-auto flex flex-col items-center py-16 sm:py-24"
+>
+  <!-- Mono kicker -->
+  <div
+    class="bg-card/70 inline-flex items-center gap-2.5 rounded-full border px-3.5 py-1.5 backdrop-blur-sm"
+  >
+    <span class="relative flex size-1.5">
+      <span class="bg-primary/60 absolute inset-0 animate-ping rounded-full"
+      ></span>
+      <span class="bg-primary relative inline-flex size-1.5 rounded-full"
+      ></span>
+    </span>
+    <span
+      class="text-muted-foreground storages-mono text-[0.68rem] font-bold uppercase tracking-[0.18em]"
+    >
+      Storage Backends
+    </span>
+  </div>
+
+  <h2 class="mt-6 text-center text-4xl font-bold sm:text-5xl">
     Ready for any storage
   </h2>
   <p class="text-muted-foreground mt-4 text-center text-sm md:text-base">
@@ -88,23 +123,44 @@ const allStorages = [...localStorages, ...cloudStorages, ...otherStorages];
     <StorageMarquee storages={otherStorages} />
   </div>
 
-  <!-- Desktop Grid -->
+  <!-- Desktop Grid with Category Headers -->
   <div class="relative hidden w-full sm:block">
-    <div
-      class="mt-20 grid w-full grid-flow-col grid-rows-6 gap-4 md:grid-rows-4"
-    >
+    <div class="mt-16 grid w-full grid-cols-3 gap-x-4">
       {
-        allStorages.map((storage) => (
-          <div class="bg-card flex items-center gap-4 rounded-xl border p-4">
-            <img
-              src={`/images/providers/${storage.image}`}
-              class="size-8 grayscale"
-              alt={storage.name}
-            />
-            <div>
-              <p class="text-sm font-medium">{storage.name}</p>
-              <p class="text-muted-foreground text-xs">{storage.description}</p>
+        categories.map((cat) => (
+          <div class="flex flex-col gap-3">
+            <div class="flex items-baseline justify-between gap-2 px-1 pb-1">
+              <span class="text-foreground storages-mono text-[0.68rem] font-bold uppercase tracking-[0.2em]">
+                {cat.label}
+              </span>
+              <span class="bg-border/80 h-px flex-1" />
+              <span class="text-muted-foreground/60 storages-mono text-[0.62rem] font-bold tracking-wider">
+                {cat.count}
+              </span>
             </div>
+            {cat.storages.map((storage) => (
+              <div
+                class:list={[
+                  "storages-card bg-card relative flex items-center gap-4 overflow-hidden rounded-xl border p-4 transition-all",
+                ]}
+              >
+                <div
+                  class="from-primary/[0.05] pointer-events-none absolute inset-0 bg-gradient-to-br to-transparent opacity-0 transition-opacity"
+                  aria-hidden="true"
+                />
+                <img
+                  src={`/images/providers/${storage.image}`}
+                  class="relative size-8 grayscale transition-all"
+                  alt={storage.name}
+                />
+                <div class="relative min-w-0 flex-1">
+                  <p class="truncate text-sm font-semibold">{storage.name}</p>
+                  <p class="text-muted-foreground truncate text-xs">
+                    {storage.description}
+                  </p>
+                </div>
+              </div>
+            ))}
           </div>
         ))
       }
@@ -115,7 +171,17 @@ const allStorages = [...localStorages, ...cloudStorages, ...otherStorages];
     </div>
   </div>
 
-  <p class="text-muted-foreground mt-6 text-center text-sm">
-    ...and many more.
+  <p
+    class="text-muted-foreground/70 storages-mono mt-6 inline-flex items-center gap-2 text-[0.62rem] font-bold uppercase tracking-[0.18em] sm:text-[0.68rem]"
+  >
+    <span class="bg-border h-px w-8"></span>
+    + 70 more via RClone
+    <span class="bg-border h-px w-8"></span>
   </p>
 </section>
+
+<style>
+  .storages-mono {
+    font-family: "Space Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+</style>

--- a/apps/marketing/src/utils/github.ts
+++ b/apps/marketing/src/utils/github.ts
@@ -24,6 +24,6 @@ export async function getLatestReleaseVersion(): Promise<string> {
     return data.tag_name;
   } catch (error) {
     console.warn("Failed to fetch latest GitHub release version:", error);
-    return "v1.0";
+    return "v1";
   }
 }

--- a/apps/marketing/src/utils/github.ts
+++ b/apps/marketing/src/utils/github.ts
@@ -1,0 +1,29 @@
+const GITHUB_REPO = "blinkdisk/blinkdisk";
+
+export async function getLatestReleaseVersion(): Promise<string> {
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
+      {
+        headers: {
+          Accept: "application/vnd.github+json",
+          "X-GitHub-Api-Version": "2022-11-28",
+          ...(process.env.GITHUB_TOKEN
+            ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+            : {}),
+        },
+      },
+    );
+
+    if (!response.ok)
+      throw new Error(
+        `GitHub API returned ${response.status} ${response.statusText}`,
+      );
+
+    const data = (await response.json()) as { tag_name: string };
+    return data.tag_name;
+  } catch (error) {
+    console.warn("Failed to fetch latest GitHub release version:", error);
+    return "v1.0";
+  }
+}

--- a/libs/styles/globals.css
+++ b/libs/styles/globals.css
@@ -81,6 +81,7 @@
 }
 
 @theme inline {
+  --font-mono: "Space Mono", monospace;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,7 @@
     "SMTP_URL",
     "PLUNK_URL",
     "PLUNK_SECRET_KEY",
+    "GITHUB_TOKEN",
     "GITHUB_REF_NAME",
     "LOGSNAG_KEY",
     "POSTHOG_HOST",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Revamped the marketing landing for clearer structure and a more polished look, with dynamic release info in Downloads. Improves readability, consistency, and trust with refined cards, mono kickers, and standardized typography.

- **New Features**
  - Downloads: Show latest GitHub release via `@marketing/utils/github`; add arch labels and full-width `DownloadButton` (`className`).
  - Sections: Redesigned Problems, Solution, Storages, Quote, and FAQ with mono kickers, refined cards (window chrome, numbering, dashed connectors), and clearer copy; added quote highlight.
  - Storages grid: Grouped by Local, Cloud, and Protocols with counts and hover states; marquees kept; "+ 70 more via RClone".
  - Typography: Standardized monospaced text via `font-mono`/`--font-mono`; removed inline font styles.
  - Optional: Set `GITHUB_TOKEN` to raise rate limits for the version fetch.

- **Bug Fixes**
  - Reliability: Downloads version falls back to "v1" on GitHub API errors; fixed FAQ contact email.

<sup>Written for commit f2dda51c23334ce8451f0480a703a54b99f1520a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

