### PR TITLE
feat(desktop): improved first vault flow

### DIFF
--- a/apps/desktop/src/components/dialogs/create-vault/details.tsx
+++ b/apps/desktop/src/components/dialogs/create-vault/details.tsx
@@ -3,22 +3,28 @@ import { useStore } from "@blinkdisk/forms/use-app-form";
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
 import { ProviderConfig } from "@blinkdisk/schemas/providers";
 import { Alert, AlertDescription, AlertTitle } from "@blinkdisk/ui/alert";
+import { Button } from "@blinkdisk/ui/button";
+import { CloudBlinkIcon } from "@desktop/components/icons/cloudblink";
 import { useCreateVaultForm } from "@desktop/hooks/forms/use-create-vault-form";
 import { useTheme } from "@desktop/hooks/use-theme";
 import { useNavigate } from "@tanstack/react-router";
-import { AlertTriangleIcon } from "lucide-react";
+import { AlertTriangleIcon, SquarePenIcon } from "lucide-react";
 import PasswordStrengthBar from "react-password-strength-bar";
 
 type CreateVaultDetailsProps = {
   providerType?: StorageProviderType;
   onSubmit?: () => void;
   config?: ProviderConfig;
+  autoSelectedProvider?: boolean;
+  onChangeStorage?: () => void;
 };
 
 export function CreateVaultDetails({
   providerType,
   onSubmit,
   config,
+  autoSelectedProvider,
+  onChangeStorage,
 }: CreateVaultDetailsProps) {
   const { t } = useAppTranslation("vault.createDialog.details");
   const { dark } = useTheme();
@@ -52,6 +58,28 @@ export function CreateVaultDetails({
       }}
       className="mt-8 flex flex-col gap-6"
     >
+      {autoSelectedProvider && providerType === "CLOUDBLINK" ? (
+        <div className="border-border bg-card flex flex-col gap-4 rounded-lg border p-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="grid min-w-0 gap-2">
+            <CloudBlinkIcon className="mt-1 h-3.5 w-auto" />
+            <div className="grid gap-1">
+              <p className="text-muted-foreground max-w-68 text-xs leading-4">
+                {t("storage.description")}
+              </p>
+            </div>
+          </div>
+          <Button
+            onClick={onChangeStorage}
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="w-full shrink-0 sm:w-auto"
+          >
+            <SquarePenIcon />
+            {t("storage.change")}
+          </Button>
+        </div>
+      ) : null}
       <form.AppField name="name">
         {(field) => (
           <field.Text

--- a/apps/desktop/src/components/dialogs/create-vault/index.tsx
+++ b/apps/desktop/src/components/dialogs/create-vault/index.tsx
@@ -1,6 +1,4 @@
-import { StorageProviderType } from "@blinkdisk/constants/providers";
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
-import { ProviderConfig } from "@blinkdisk/schemas/providers";
 import { Button } from "@blinkdisk/ui/button";
 import {
   Dialog,
@@ -12,11 +10,13 @@ import { CreateVaultConfig } from "@desktop/components/dialogs/create-vault/conf
 import { CreateVaultDetails } from "@desktop/components/dialogs/create-vault/details";
 import { CreateVaultProviders } from "@desktop/components/dialogs/create-vault/providers";
 import { CreateVaultVariant } from "@desktop/components/dialogs/create-vault/variant";
-import { useCreateVaultDialog } from "@desktop/hooks/state/use-create-vault-dialog";
+import { useVaultList } from "@desktop/hooks/queries/use-vault-list";
+import {
+  CreateVaultStep,
+  useCreateVaultDialog,
+} from "@desktop/hooks/state/use-create-vault-dialog";
 import { ArrowLeftIcon } from "lucide-react";
-import { useCallback, useState } from "react";
-
-type CreateVaultStep = "VARIANT" | "PROVIDER" | "CONFIG" | "DETAILS";
+import { useCallback } from "react";
 
 const backButton: Record<CreateVaultStep, CreateVaultStep> = {
   VARIANT: "VARIANT",
@@ -27,32 +27,38 @@ const backButton: Record<CreateVaultStep, CreateVaultStep> = {
 
 export function CreateVaultDialog() {
   const { t } = useAppTranslation("vault.createDialog");
-
-  const [step, setStep] = useState<CreateVaultStep>("VARIANT");
-  const [provider, setProvider] = useState<StorageProviderType | undefined>();
-  const [config, setConfig] = useState<ProviderConfig | undefined>();
-  const { isOpen, setIsOpen } = useCreateVaultDialog();
+  const { data: vaults } = useVaultList();
+  const { isOpen, setIsOpen, options, setOptions, resetOptions } =
+    useCreateVaultDialog();
+  const { step, provider, config, autoSelectedProvider } = options;
 
   const close = useCallback(() => {
     setIsOpen(false);
   }, [setIsOpen]);
 
   const reset = useCallback(() => {
-    setStep("VARIANT");
-    setProvider(undefined);
-    setConfig(undefined);
-  }, [setStep, setProvider, setConfig]);
+    resetOptions();
+  }, [resetOptions]);
+
+  const showFirstVaultTitle = !vaults?.length;
 
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen} onClosed={reset}>
       <DialogContent className="w-120 block max-h-[80vh] overflow-y-auto">
         <div className="flex items-center gap-3">
-          {step !== "VARIANT" ? (
+          {step !== "VARIANT" && !autoSelectedProvider ? (
             <Button
               onClick={() => {
                 if (step === "DETAILS" && provider == "CLOUDBLINK")
-                  setStep("VARIANT");
-                else setStep(backButton[step]);
+                  setOptions({
+                    step: "VARIANT",
+                    autoSelectedProvider: false,
+                  });
+                else
+                  setOptions({
+                    step: backButton[step],
+                    autoSelectedProvider: false,
+                  });
               }}
               variant="ghost"
               size="icon-xs"
@@ -60,7 +66,9 @@ export function CreateVaultDialog() {
               <ArrowLeftIcon />
             </Button>
           ) : null}
-          <DialogTitle>{t("title")}</DialogTitle>
+          <DialogTitle>
+            {showFirstVaultTitle ? t("title.first") : t("title.default")}
+          </DialogTitle>
         </div>
         <DialogDescription className="sr-only">
           {t("description")}
@@ -68,18 +76,26 @@ export function CreateVaultDialog() {
         {step === "VARIANT" ? (
           <CreateVaultVariant
             selectCloud={() => {
-              setProvider("CLOUDBLINK");
-              setConfig(undefined);
-              setStep("DETAILS");
+              setOptions({
+                provider: "CLOUDBLINK",
+                config: undefined,
+                step: "DETAILS",
+                autoSelectedProvider: false,
+              });
             }}
-            selectCustom={() => setStep("PROVIDER")}
+            selectCustom={() =>
+              setOptions({ step: "PROVIDER", autoSelectedProvider: false })
+            }
           />
         ) : step === "PROVIDER" ? (
           <CreateVaultProviders
             selectProvider={(newProvider) => {
-              if (provider !== newProvider) setConfig(undefined);
-              setProvider(newProvider);
-              setStep("CONFIG");
+              setOptions({
+                provider: newProvider,
+                config: provider !== newProvider ? undefined : config,
+                step: "CONFIG",
+                autoSelectedProvider: false,
+              });
             }}
           />
         ) : step === "CONFIG" ? (
@@ -87,8 +103,11 @@ export function CreateVaultDialog() {
             config={config}
             provider={provider}
             onSubmit={(config) => {
-              setConfig(config);
-              setStep("DETAILS");
+              setOptions({
+                config,
+                step: "DETAILS",
+                autoSelectedProvider: false,
+              });
             }}
           />
         ) : step === "DETAILS" ? (
@@ -99,6 +118,13 @@ export function CreateVaultDialog() {
               setTimeout(reset, 100);
             }}
             config={config}
+            autoSelectedProvider={autoSelectedProvider}
+            onChangeStorage={() =>
+              setOptions({
+                step: "VARIANT",
+                autoSelectedProvider: false,
+              })
+            }
           />
         ) : null}
       </DialogContent>

--- a/apps/desktop/src/components/sidebar/dropdowns/vault.tsx
+++ b/apps/desktop/src/components/sidebar/dropdowns/vault.tsx
@@ -75,7 +75,7 @@ export function SidebarVaultSelect({ className }: SidebarVaultSelectProps) {
               {isSyncing ? t("refreshing") : t("refresh")}
             </DropdownMenuItem>
           )}
-          <DropdownMenuItem onClick={openCreateVault}>
+          <DropdownMenuItem onClick={() => openCreateVault()}>
             <PlusIcon className="size-4" />
             {t("createVault")}
           </DropdownMenuItem>

--- a/apps/desktop/src/hooks/state/use-create-vault-dialog.ts
+++ b/apps/desktop/src/hooks/state/use-create-vault-dialog.ts
@@ -1,22 +1,78 @@
+import { StorageProviderType } from "@blinkdisk/constants/providers";
+import { ProviderConfig } from "@blinkdisk/schemas/providers";
 import { Store, useStore } from "@tanstack/react-store";
 import { useCallback } from "react";
 
-const store = new Store(false);
+export type CreateVaultStep = "VARIANT" | "PROVIDER" | "CONFIG" | "DETAILS";
+
+type CreateVaultDialogOptions = {
+  step: CreateVaultStep;
+  provider?: StorageProviderType;
+  config?: ProviderConfig;
+  autoSelectedProvider?: boolean;
+};
+
+const defaultOptions: CreateVaultDialogOptions = {
+  step: "VARIANT",
+};
+
+const store = new Store<{
+  isOpen: boolean;
+  options: CreateVaultDialogOptions;
+}>({
+  isOpen: false,
+  options: defaultOptions,
+});
 
 export function useCreateVaultDialog() {
-  const isOpen = useStore(store);
+  const { isOpen, options } = useStore(store);
 
   const setIsOpen = useCallback((to: boolean) => {
-    store.setState(to);
+    store.setState((state) => ({
+      ...state,
+      isOpen: to,
+    }));
   }, []);
 
-  function openCreateVault() {
-    store.setState(true);
-  }
+  const openCreateVault = useCallback(
+    (options: Partial<CreateVaultDialogOptions> = {}) => {
+      store.setState({
+        isOpen: true,
+        options: {
+          ...defaultOptions,
+          ...options,
+        },
+      });
+    },
+    [],
+  );
+
+  const setOptions = useCallback(
+    (options: Partial<CreateVaultDialogOptions>) => {
+      store.setState((state) => ({
+        ...state,
+        options: {
+          ...state.options,
+          ...options,
+        },
+      }));
+    },
+    [],
+  );
+
+  const resetOptions = useCallback(() => {
+    store.setState((state) => ({
+      ...state,
+      options: defaultOptions,
+    }));
+  }, []);
 
   return {
     isOpen,
+    options,
     setIsOpen,
     openCreateVault,
+    setOptions,
+    resetOptions,
   };
 }

--- a/apps/desktop/src/hooks/use-auth.ts
+++ b/apps/desktop/src/hooks/use-auth.ts
@@ -39,11 +39,12 @@ export function useAuth() {
         posthog.identify(accountId);
       }
 
-      await window.electron.store.set("currentAccountId", accountId);
-
-      await queryClient.invalidateQueries({
-        queryKey: queryKeys.account.detail(),
-      });
+      await Promise.all([
+        window.electron.store.set("currentAccountId", accountId),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.account.detail(),
+        }),
+      ]);
     },
     [queryClient, queryKeys, posthog],
   );

--- a/apps/desktop/src/routes/{-$accountId}/index.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/index.tsx
@@ -8,7 +8,7 @@ import { useCreateVaultDialog } from "@desktop/hooks/state/use-create-vault-dial
 import { useAccountId } from "@desktop/hooks/use-account-id";
 import { createFileRoute } from "@tanstack/react-router";
 import { CloudAlertIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 export const Route = createFileRoute("/{-$accountId}/")({
   component: RouteComponent,
@@ -19,6 +19,7 @@ function RouteComponent() {
   const { accountId, isOnlineAccount } = useAccountId();
   const { openCreateVault } = useCreateVaultDialog();
   const { data: vaults } = useVaultList();
+  const openedVaultDialog = useRef(false);
 
   const { mutate: sync, isPending: isSyncing } = useSync();
 
@@ -46,6 +47,21 @@ function RouteComponent() {
     });
   }, [accountId, vaults, navigate]);
 
+  const openCreateCloudBlink = useCallback(() => {
+    openCreateVault({
+      step: "DETAILS",
+      provider: "CLOUDBLINK",
+      autoSelectedProvider: true,
+    });
+  }, [openCreateVault]);
+
+  useEffect(() => {
+    if (!isOnlineAccount || vaults?.length || openedVaultDialog.current) return;
+
+    openedVaultDialog.current = true;
+    openCreateCloudBlink();
+  }, [isOnlineAccount, openCreateCloudBlink, vaults]);
+
   if (!vaults?.length)
     return (
       <Empty
@@ -65,7 +81,12 @@ function RouteComponent() {
             {t("noVaults.refresh")}
           </Button>
         ) : null}
-        <Button onClick={openCreateVault} size="lg">
+        <Button
+          onClick={() =>
+            isOnlineAccount ? openCreateCloudBlink() : openCreateVault()
+          }
+          size="lg"
+        >
           <PlusIcon />
           {t("noVaults.add")}
         </Button>

--- a/apps/electron/src/db/index.ts
+++ b/apps/electron/src/db/index.ts
@@ -109,8 +109,11 @@ export async function initAccountCollections(accountId: string) {
 
     if (!lastSync) {
       log.info(accountId, "not synced yet, syncing...");
-      syncManager.sync(vaultName);
-      syncManager.sync(configName);
+
+      await Promise.all([
+        syncManager.sync(vaultName),
+        syncManager.sync(configName),
+      ]);
     }
   }
 

--- a/locales/en/vault.json
+++ b/locales/en/vault.json
@@ -6,7 +6,10 @@
     "add": "Add vault"
   },
   "createDialog": {
-    "title": "Create new vault",
+    "title": {
+      "default": "Create new vault",
+      "first": "Create your first vault"
+    },
     "description": "Create a new vault.",
     "variant": {
       "cloudblink": {
@@ -60,6 +63,10 @@
       "warning": {
         "title": "Never forget this password",
         "description": "We never store this password on our servers and there is no way to recover it. If you loose this password, you might not be able to restore your backups."
+      },
+      "storage": {
+        "description": "BlinkDisk manages the cloud storage for this vault.",
+        "change": "Change storage"
       },
       "submit": "Create vault"
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improve the first-vault flow by auto-opening the Create Vault dialog for new online accounts, defaulting to CloudBlink, and showing a clear “first vault” title with storage info. Dialog state is centralized for direct step entry and smoother navigation, and initial account sync is awaited to avoid race conditions.

- **New Features**
  - Auto-open Create Vault for first-time online accounts with no vaults.
  - Default to CloudBlink and show a storage info card with a “Change storage” action.
  - Title switches to “Create your first vault”; empty state “Add vault” uses CloudBlink for online accounts.

- **Refactors**
  - Centralized dialog state in `useCreateVaultDialog` (step/provider/config/autoSelectedProvider) with programmatic `openCreateVault(options)`.
  - Await initial account collection sync and batch async calls in `useAuth` to prevent early reads and race conditions.
  - Improved back/reset behavior (config resets on provider change; back button hidden when provider is auto-selected); fixed invoking `openCreateVault()` from the sidebar.

<sup>Written for commit a449dbdba18818405a6f408b3b7a8fab7d73f837. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

