### PR TITLE
fix(desktop): checkbox click in file list

### DIFF
--- a/apps/desktop/src/components/directories/row.tsx
+++ b/apps/desktop/src/components/directories/row.tsx
@@ -12,6 +12,9 @@ type DirectoryItemRowProps = {
   reset: () => void;
 };
 
+const INTERACTIVE_ROW_TARGET_SELECTOR =
+  'a, button, input, label, select, textarea, [role="button"], [role="checkbox"], [role="menuitem"], [data-no-row-click]';
+
 export function DirectoryItemRow({
   row,
   virtualRow,
@@ -25,7 +28,10 @@ export function DirectoryItemRow({
   return (
     <TableRow
       data-state={row.getIsSelected() && "selected"}
-      onClick={() => {
+      onClick={(event) => {
+        const target = event.target as HTMLElement;
+        if (target.closest(INTERACTIVE_ROW_TARGET_SELECTOR)) return;
+
         if (row.original?.type === "DIRECTORY") {
           reset();
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent unintended row activation in the desktop file list by ignoring row clicks that start on interactive elements. Clicking checkboxes, buttons, or inputs now only affects the control and no longer selects or navigates the row.

<sup>Written for commit b1b16c9a581648b62ba8977862270d729291e2bd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

