### PR TITLE
fix(desktop): typo in password warning message

### DIFF
--- a/locales/en/vault.json
+++ b/locales/en/vault.json
@@ -62,7 +62,7 @@
       },
       "warning": {
         "title": "Never forget this password",
-        "description": "We never store this password on our servers and there is no way to recover it. If you loose this password, you might not be able to restore your backups."
+        "description": "We never store this password on our servers and there is no way to recover it. If you lose this password, you might not be able to restore your backups."
       },
       "storage": {
         "description": "BlinkDisk manages the cloud storage for this vault.",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix typo in the vault password warning message to improve clarity. Replaced "loose" with "lose" in `locales/en/vault.json`; text-only change with no behavior impact.

<sup>Written for commit 0d8557149499d2140fba4ddfccf47d03afdc7fa0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

