### PR TITLE
fix(desktop): opening of create vault dialog

### DIFF
--- a/apps/desktop/src/hooks/use-auth.ts
+++ b/apps/desktop/src/hooks/use-auth.ts
@@ -1,9 +1,11 @@
 import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
 import { useAccountList } from "@desktop/hooks/queries/use-account-list";
 import { useAuthDialog } from "@desktop/hooks/state/use-auth-dialog";
+import { useCreateVaultDialog } from "@desktop/hooks/state/use-create-vault-dialog";
 import { useAccountId } from "@desktop/hooks/use-account-id";
 import { useAppStorage } from "@desktop/hooks/use-app-storage";
 import { useQueryKey } from "@desktop/hooks/use-query-key";
+import { getVaultCollection } from "@desktop/lib/db";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { usePostHog } from "posthog-js/react";
@@ -18,6 +20,7 @@ export function useAuth() {
   const { accountId } = useAccountId();
   const { queryKeys } = useQueryKey();
   const { openAuthDialog } = useAuthDialog();
+  const { openCreateVault } = useCreateVaultDialog();
 
   const [authenticated, setAuthenticated] = useAppStorage(
     "authenticated",
@@ -45,8 +48,20 @@ export function useAuth() {
           queryKey: queryKeys.account.detail(),
         }),
       ]);
+
+      const hasActiveVaults = getVaultCollection(accountId)
+        .find({ status: "ACTIVE" })
+        .fetch().length;
+
+      if (!local && !hasActiveVaults) {
+        openCreateVault({
+          step: "DETAILS",
+          provider: "CLOUDBLINK",
+          autoSelectedProvider: true,
+        });
+      }
     },
-    [queryClient, queryKeys, posthog],
+    [queryClient, queryKeys, posthog, openCreateVault],
   );
 
   const selectAccount = useCallback(

--- a/apps/desktop/src/routes/{-$accountId}/index.tsx
+++ b/apps/desktop/src/routes/{-$accountId}/index.tsx
@@ -8,7 +8,7 @@ import { useCreateVaultDialog } from "@desktop/hooks/state/use-create-vault-dial
 import { useAccountId } from "@desktop/hooks/use-account-id";
 import { createFileRoute } from "@tanstack/react-router";
 import { CloudAlertIcon, PlusIcon, RefreshCwIcon } from "lucide-react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 
 export const Route = createFileRoute("/{-$accountId}/")({
   component: RouteComponent,
@@ -19,7 +19,6 @@ function RouteComponent() {
   const { accountId, isOnlineAccount } = useAccountId();
   const { openCreateVault } = useCreateVaultDialog();
   const { data: vaults } = useVaultList();
-  const openedVaultDialog = useRef(false);
 
   const { mutate: sync, isPending: isSyncing } = useSync();
 
@@ -54,13 +53,6 @@ function RouteComponent() {
       autoSelectedProvider: true,
     });
   }, [openCreateVault]);
-
-  useEffect(() => {
-    if (!isOnlineAccount || vaults?.length || openedVaultDialog.current) return;
-
-    openedVaultDialog.current = true;
-    openCreateCloudBlink();
-  }, [isOnlineAccount, openCreateCloudBlink, vaults]);
 
   if (!vaults?.length)
     return (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the create vault dialog so it opens at the right time: immediately after authentication for online accounts with no active vaults, and never for the local account.

- **Bug Fixes**
  - Moved the dialog trigger into the auth flow to ensure correct timing after sign-in.
  - Open only when zero active vaults are found; uses the DB collection to check.
  - Removed the route-level effect and ref that could cause missed or duplicate openings.
  - Preselects the `CLOUDBLINK` provider and starts at the Details step.

<sup>Written for commit 9fc56b39ef050842eab8b40fcaa0c12db6473378. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

