### PR TITLE
fix: change accessKeyType to accessKeyId

### DIFF
--- a/apps/electron/src/vault/mapping.test.ts
+++ b/apps/electron/src/vault/mapping.test.ts
@@ -43,9 +43,10 @@ describe("mapConfigFields", () => {
     });
   });
 
-  it("maps S3 fields using coreMapping", () => {
-    const result = mapConfigFields("AMAZON_S3", {
-      accessKeyType: "AKIA123",
+  it("maps S3-compatible fields using coreMapping", () => {
+    const result = mapConfigFields("S3_COMPATIBLE", {
+      endpoint: "https://s3.example.com",
+      accessKeyId: "AKIA123",
       accessKeySecret: "secret",
       bucket: "my-bucket",
       region: "us-east-1",
@@ -54,6 +55,7 @@ describe("mapConfigFields", () => {
     });
 
     expect(result).toEqual({
+      endpoint: "https://s3.example.com",
       accessKeyID: "AKIA123",
       secretAccessKey: "secret",
       bucket: "my-bucket",

--- a/libs/constants/src/providers.ts
+++ b/libs/constants/src/providers.ts
@@ -29,7 +29,7 @@ const fileSystemBase = {
 const s3Base = {
   coreType: "s3",
   coreMapping: {
-    accessKeyType: "accessKeyID",
+    accessKeyId: "accessKeyID",
     accessKeySecret: "secretAccessKey",
     disableTls: "doNotUseTLS",
     disableTlsVerification: "doNotVerifyTLS",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix S3-compatible credential mapping by mapping `accessKeyId` to core `accessKeyID` so auth works with S3-compatible backends. Updated tests to use `S3_COMPATIBLE`, include `endpoint`, and verify the mapping.

<sup>Written for commit 3a3af08bd9724d4cd58ce06134152ac59c34bf35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

