### PR TITLE
feat(desktop): add sidebar alert carousel

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,6 +37,7 @@
     "@tanstack/react-virtual": "^3.13.12",
     "@trpc/client": "^10.45.2",
     "date-fns": "^4.1.0",
+    "embla-carousel-auto-height": "8.6.0",
     "filesize": "^11.0.2",
     "framer-motion": "^12.5.0",
     "lucide-react": "^1.7.0",

--- a/apps/desktop/src/components/sidebar/alerts.tsx
+++ b/apps/desktop/src/components/sidebar/alerts.tsx
@@ -35,7 +35,7 @@ export function SidebarAlerts() {
     });
   }
 
-  if (isOffline) {
+  if (!isOffline) {
     alerts.push({
       key: "offline",
       alert: <SidebarOfflineAlert />,
@@ -83,7 +83,7 @@ export function SidebarAlerts() {
 
   return (
     <Carousel
-      opts={{ align: "start" }}
+      opts={{ align: "start", loop: true }}
       setApi={setCarouselApi}
       className="group/alerts"
     >

--- a/apps/desktop/src/components/sidebar/alerts.tsx
+++ b/apps/desktop/src/components/sidebar/alerts.tsx
@@ -3,6 +3,8 @@ import {
   type CarouselApi,
   CarouselContent,
   CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
 } from "@blinkdisk/ui/carousel";
 import { SidebarOfflineAlert } from "@desktop/components/sidebar/offline-alert";
 import { SidebarStorageAlert } from "@desktop/components/sidebar/storage-alert";
@@ -36,7 +38,7 @@ export function SidebarAlerts() {
     });
   }
 
-  if (!isOffline) {
+  if (isOffline) {
     alerts.push({
       key: "offline",
       alert: <SidebarOfflineAlert />,
@@ -96,21 +98,33 @@ export function SidebarAlerts() {
         ))}
       </CarouselContent>
       {scrollSnaps.length > 1 ? (
-        <div className="mt-2 flex justify-center gap-1.5">
-          {scrollSnaps.map((scrollSnap, index) => (
-            <button
-              key={scrollSnap}
-              type="button"
-              aria-label={`Go to alert ${index + 1}`}
-              aria-current={index === currentAlert ? "true" : undefined}
-              onClick={() => carouselApi?.scrollTo(index)}
-              className={
-                index === currentAlert
-                  ? "bg-foreground/70 size-1.5 rounded-full"
-                  : "bg-foreground/20 hover:bg-foreground/40 size-1.5 rounded-full transition-colors"
-              }
+        <div className="mt-2 flex items-center justify-between">
+          <div className="flex gap-0.5">
+            <CarouselPrevious
+              variant="ghost"
+              className="text-muted-foreground static size-6 translate-y-0"
             />
-          ))}
+            <CarouselNext
+              variant="ghost"
+              className="text-muted-foreground static size-6 translate-y-0"
+            />
+          </div>
+          <div className="flex gap-1.5">
+            {scrollSnaps.map((scrollSnap, index) => (
+              <button
+                key={scrollSnap}
+                type="button"
+                aria-label={`Go to alert ${index + 1}`}
+                aria-current={index === currentAlert ? "true" : undefined}
+                onClick={() => carouselApi?.scrollTo(index)}
+                className={
+                  index === currentAlert
+                    ? "bg-foreground/70 size-1.5 rounded-full"
+                    : "bg-foreground/20 hover:bg-foreground/40 size-1.5 rounded-full transition-colors"
+                }
+              />
+            ))}
+          </div>
         </div>
       ) : null}
     </Carousel>

--- a/apps/desktop/src/components/sidebar/alerts.tsx
+++ b/apps/desktop/src/components/sidebar/alerts.tsx
@@ -1,0 +1,117 @@
+import {
+  Carousel,
+  type CarouselApi,
+  CarouselContent,
+  CarouselItem,
+} from "@blinkdisk/ui/carousel";
+import { SidebarOfflineAlert } from "@desktop/components/sidebar/offline-alert";
+import { SidebarStorageAlert } from "@desktop/components/sidebar/storage-alert";
+import { SidebarTrialAlert } from "@desktop/components/sidebar/trial-alert";
+import { SidebarUpdateAlert } from "@desktop/components/sidebar/update-alert";
+import { useSpace } from "@desktop/hooks/queries/use-space";
+import { useUpdateDialog } from "@desktop/hooks/state/use-update-dialog";
+import { useOffline } from "@desktop/hooks/use-offline";
+import { type ReactNode, useEffect, useState } from "react";
+
+type SidebarAlertSlide = {
+  key: string;
+  alert: ReactNode;
+};
+
+export function SidebarAlerts() {
+  const { isOffline } = useOffline();
+  const { data: space } = useSpace();
+  const { status } = useUpdateDialog();
+  const [carouselApi, setCarouselApi] = useState<CarouselApi>();
+  const [currentAlert, setCurrentAlert] = useState(0);
+
+  const storagePercentage = space ? space.used / space.capacity : 0;
+  const alerts: SidebarAlertSlide[] = [];
+
+  if (status?.available) {
+    alerts.push({
+      key: "update",
+      alert: <SidebarUpdateAlert />,
+    });
+  }
+
+  if (isOffline) {
+    alerts.push({
+      key: "offline",
+      alert: <SidebarOfflineAlert />,
+    });
+  }
+
+  if (space?.trialEndsAt) {
+    alerts.push({
+      key: "trial",
+      alert: (
+        <SidebarTrialAlert
+          capacity={space.capacity}
+          trialEndsAt={space.trialEndsAt}
+        />
+      ),
+    });
+  }
+
+  if (storagePercentage >= 0.8) {
+    alerts.push({
+      key: "storage",
+      alert: <SidebarStorageAlert />,
+    });
+  }
+
+  useEffect(() => {
+    if (!carouselApi) return;
+
+    setCurrentAlert(carouselApi.selectedScrollSnap());
+
+    const handleSelect = () => {
+      setCurrentAlert(carouselApi.selectedScrollSnap());
+    };
+
+    carouselApi.on("select", handleSelect);
+    carouselApi.on("reInit", handleSelect);
+
+    return () => {
+      carouselApi.off("select", handleSelect);
+      carouselApi.off("reInit", handleSelect);
+    };
+  }, [carouselApi]);
+
+  if (!alerts.length) return null;
+
+  return (
+    <Carousel
+      opts={{ align: "start" }}
+      setApi={setCarouselApi}
+      className="group/alerts"
+    >
+      <CarouselContent className="-ml-2 items-end">
+        {alerts.map(({ alert, key }) => (
+          <CarouselItem key={key} className="pl-2">
+            {alert}
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      {alerts.length > 1 ? (
+        <div className="mt-2 flex justify-center gap-1.5">
+          {alerts.map(({ key }, index) => (
+            <button
+              key={key}
+              type="button"
+              aria-label={`Go to alert ${index + 1}`}
+              aria-current={index === currentAlert ? "true" : undefined}
+              onClick={() => carouselApi?.scrollTo(index)}
+              className={
+                index === currentAlert
+                  ? "bg-foreground/70 size-1.5 rounded-full"
+                  : "bg-foreground/20 hover:bg-foreground/40 size-1.5 rounded-full transition-colors"
+              }
+            />
+          ))}
+        </div>
+      ) : null}
+    </Carousel>
+  );
+}

--- a/apps/desktop/src/components/sidebar/alerts.tsx
+++ b/apps/desktop/src/components/sidebar/alerts.tsx
@@ -13,6 +13,7 @@ import { SidebarUpdateAlert } from "@desktop/components/sidebar/update-alert";
 import { useSpace } from "@desktop/hooks/queries/use-space";
 import { useUpdateDialog } from "@desktop/hooks/state/use-update-dialog";
 import { useOffline } from "@desktop/hooks/use-offline";
+import AutoHeight from "embla-carousel-auto-height";
 import { type ReactNode, useEffect, useState } from "react";
 
 type SidebarAlertSlide = {
@@ -87,10 +88,11 @@ export function SidebarAlerts() {
   return (
     <Carousel
       opts={{ align: "start", loop: true }}
+      plugins={[AutoHeight()]}
       setApi={setCarouselApi}
       className="group/alerts"
     >
-      <CarouselContent className="-ml-2 items-end">
+      <CarouselContent className="-ml-2 items-start transition-[height]">
         {alerts.map(({ alert, key }) => (
           <CarouselItem key={key} className="pl-2">
             {alert}

--- a/apps/desktop/src/components/sidebar/alerts.tsx
+++ b/apps/desktop/src/components/sidebar/alerts.tsx
@@ -24,6 +24,7 @@ export function SidebarAlerts() {
   const { status } = useUpdateDialog();
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
   const [currentAlert, setCurrentAlert] = useState(0);
+  const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
 
   const storagePercentage = space ? space.used / space.capacity : 0;
   const alerts: SidebarAlertSlide[] = [];
@@ -64,18 +65,18 @@ export function SidebarAlerts() {
   useEffect(() => {
     if (!carouselApi) return;
 
-    setCurrentAlert(carouselApi.selectedScrollSnap());
-
-    const handleSelect = () => {
+    const updateCarouselState = () => {
+      setScrollSnaps(carouselApi.scrollSnapList());
       setCurrentAlert(carouselApi.selectedScrollSnap());
     };
 
-    carouselApi.on("select", handleSelect);
-    carouselApi.on("reInit", handleSelect);
+    updateCarouselState();
+    carouselApi.on("select", updateCarouselState);
+    carouselApi.on("reInit", updateCarouselState);
 
     return () => {
-      carouselApi.off("select", handleSelect);
-      carouselApi.off("reInit", handleSelect);
+      carouselApi.off("select", updateCarouselState);
+      carouselApi.off("reInit", updateCarouselState);
     };
   }, [carouselApi]);
 
@@ -94,11 +95,11 @@ export function SidebarAlerts() {
           </CarouselItem>
         ))}
       </CarouselContent>
-      {alerts.length > 1 ? (
+      {scrollSnaps.length > 1 ? (
         <div className="mt-2 flex justify-center gap-1.5">
-          {alerts.map(({ key }, index) => (
+          {scrollSnaps.map((scrollSnap, index) => (
             <button
-              key={key}
+              key={scrollSnap}
               type="button"
               aria-label={`Go to alert ${index + 1}`}
               aria-current={index === currentAlert ? "true" : undefined}

--- a/apps/desktop/src/components/sidebar/index.tsx
+++ b/apps/desktop/src/components/sidebar/index.tsx
@@ -13,28 +13,21 @@ import { AccountMenuDropdown } from "@desktop/components/accounts/menu-dropdown"
 import { AccountPreview } from "@desktop/components/accounts/preview";
 import { AccountSelectDropdown } from "@desktop/components/accounts/select-dropdown";
 import { SidebarAddFolder } from "@desktop/components/sidebar/add-folder";
+import { SidebarAlerts } from "@desktop/components/sidebar/alerts";
 import { SidebarSelects } from "@desktop/components/sidebar/dropdowns";
 import { SidebarFolderList } from "@desktop/components/sidebar/folder-list";
-import { SidebarOfflineAlert } from "@desktop/components/sidebar/offline-alert";
 import { SidebarSkeletonTheme } from "@desktop/components/sidebar/skeleton-theme";
-import { SidebarStorageAlert } from "@desktop/components/sidebar/storage-alert";
-import { SidebarTrialAlert } from "@desktop/components/sidebar/trial-alert";
-import { SidebarUpdateAlert } from "@desktop/components/sidebar/update-alert";
 import { useFolderList } from "@desktop/hooks/queries/core/use-folder-list";
 import { useAccount } from "@desktop/hooks/queries/use-account";
-import { useSpace } from "@desktop/hooks/queries/use-space";
 import { useAccountId } from "@desktop/hooks/use-account-id";
-import { useOffline } from "@desktop/hooks/use-offline";
 import { Link, useLocation, useParams } from "@tanstack/react-router";
 import { EllipsisVerticalIcon, HomeIcon, SettingsIcon } from "lucide-react";
 import type { ComponentProps } from "react";
 
 export function Sidebar({ ...props }: ComponentProps<typeof SidebarContainer>) {
   const { isLocalAccount } = useAccountId();
-  const { isOffline } = useOffline();
   const { data: account } = useAccount();
   const { data: folders } = useFolderList();
-  const { data: space } = useSpace();
 
   const { accountId, vaultId, hostName, userName } = useParams({
     strict: false,
@@ -98,17 +91,7 @@ export function Sidebar({ ...props }: ComponentProps<typeof SidebarContainer>) {
         </SidebarContent>
         <SidebarFooter>
           <SidebarMenu className="gap-4">
-            <SidebarUpdateAlert />
-            {isOffline ? (
-              <SidebarOfflineAlert />
-            ) : space?.trialEndsAt ? (
-              <SidebarTrialAlert
-                capacity={space.capacity}
-                trialEndsAt={space.trialEndsAt}
-              />
-            ) : (
-              <SidebarStorageAlert />
-            )}
+            <SidebarAlerts />
             <SidebarAddFolder />
             <SidebarMenuItem className="flex items-center">
               <AccountSelectDropdown>

--- a/apps/desktop/src/components/sidebar/storage-alert.tsx
+++ b/apps/desktop/src/components/sidebar/storage-alert.tsx
@@ -21,7 +21,6 @@ export function SidebarStorageAlert() {
     return percentage >= 0.98;
   }, [percentage]);
 
-  if (percentage < 0.8) return null;
   return (
     <SidebarMenuItem>
       <Alert variant={full ? "destructive" : "warn"} className="rounded-xl p-4">

--- a/apps/desktop/src/components/sidebar/storage-alert.tsx
+++ b/apps/desktop/src/components/sidebar/storage-alert.tsx
@@ -4,6 +4,7 @@ import { Button } from "@blinkdisk/ui/button";
 import { SidebarMenuItem } from "@blinkdisk/ui/sidebar";
 import { useSpace } from "@desktop/hooks/queries/use-space";
 import { useUpgradeDialog } from "@desktop/hooks/state/use-upgrade-dialog";
+import { CircleFadingArrowUpIcon } from "lucide-react";
 import { useMemo } from "react";
 
 export function SidebarStorageAlert() {
@@ -35,6 +36,7 @@ export function SidebarStorageAlert() {
             variant={full ? "destructive" : "warn"}
             onClick={openUpgradeDialog}
           >
+            <CircleFadingArrowUpIcon />
             {t("button")}
           </Button>
         </AlertDescription>

--- a/apps/desktop/src/components/sidebar/trial-alert.tsx
+++ b/apps/desktop/src/components/sidebar/trial-alert.tsx
@@ -20,15 +20,19 @@ export function SidebarTrialAlert({
 }: SidebarTrialAlertProps) {
   const { t } = useAppTranslation("sidebar.trialAlert");
   const { openUpgradeDialog } = useUpgradeDialog();
+
   const trialEndsIn = useRelativeTime(trialEndsAt);
+
   const daysUntilTrialEnds =
     (new Date(trialEndsAt).getTime() - Date.now()) / DAY_IN_MS;
+
   const variant =
     daysUntilTrialEnds < 7
       ? "destructive"
       : daysUntilTrialEnds < 14
         ? "warn"
         : "info";
+
   const buttonVariant =
     variant === "destructive"
       ? "destructive"

--- a/apps/desktop/src/components/sidebar/update-alert.tsx
+++ b/apps/desktop/src/components/sidebar/update-alert.tsx
@@ -7,9 +7,7 @@ import { DownloadIcon } from "lucide-react";
 
 export function SidebarUpdateAlert() {
   const { t } = useAppTranslation("sidebar.updateAlert");
-  const { setIsOpen, status } = useUpdateDialog();
-
-  if (!status?.available) return null;
+  const { setIsOpen } = useUpdateDialog();
 
   return (
     <SidebarMenuItem>

--- a/libs/ui/package.json
+++ b/libs/ui/package.json
@@ -9,10 +9,10 @@
     "./*": "./src/*.tsx"
   },
   "devDependencies": {
+    "@blinkdisk/constants": "workspace:*",
+    "@blinkdisk/hooks": "workspace:*",
     "@blinkdisk/typescript": "workspace:*",
     "@blinkdisk/utils": "workspace:*",
-    "@blinkdisk/hooks": "workspace:*",
-    "@blinkdisk/constants": "workspace:*",
     "@types/node": "^22.13.9",
     "@types/react": "19.0.10",
     "@types/react-dom": "19.0.4",
@@ -22,6 +22,7 @@
     "@base-ui/react": "^1.2.0",
     "@types/twemoji-parser": "^13.1.4",
     "class-variance-authority": "^0.7.1",
+    "embla-carousel-react": "^8.6.0",
     "frimousse": "^0.3.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.483.0",

--- a/libs/ui/src/carousel.tsx
+++ b/libs/ui/src/carousel.tsx
@@ -237,5 +237,4 @@ export {
   CarouselItem,
   CarouselNext,
   CarouselPrevious,
-  useCarousel,
 };

--- a/libs/ui/src/carousel.tsx
+++ b/libs/ui/src/carousel.tsx
@@ -1,0 +1,241 @@
+import { cn } from "@blinkdisk/utils/class";
+import { Button } from "@ui/button";
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react";
+import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import * as React from "react";
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: "horizontal" | "vertical";
+  setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />");
+  }
+
+  return context;
+}
+
+function Carousel({
+  orientation = "horizontal",
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & CarouselProps) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === "horizontal" ? "x" : "y",
+    },
+    plugins,
+  );
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+  const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+  const onSelect = React.useCallback((api: CarouselApi) => {
+    if (!api) return;
+    setCanScrollPrev(api.canScrollPrev());
+    setCanScrollNext(api.canScrollNext());
+  }, []);
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev();
+  }, [api]);
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext();
+  }, [api]);
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        scrollPrev();
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault();
+        scrollNext();
+      }
+    },
+    [scrollPrev, scrollNext],
+  );
+
+  React.useEffect(() => {
+    if (!api || !setApi) return;
+    setApi(api);
+  }, [api, setApi]);
+
+  React.useEffect(() => {
+    if (!api) return;
+    onSelect(api);
+    api.on("reInit", onSelect);
+    api.on("select", onSelect);
+
+    return () => {
+      api?.off("select", onSelect);
+    };
+  }, [api, onSelect]);
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation:
+          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      {/* biome-ignore lint/a11y/useSemanticElements: shadcn recommends this */}
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn("relative", className)}
+        role="region"
+        aria-roledescription="carousel"
+        data-slot="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  );
+}
+
+function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
+  const { carouselRef, orientation } = useCarousel();
+
+  return (
+    <div
+      ref={carouselRef}
+      className="overflow-hidden"
+      data-slot="carousel-content"
+    >
+      <div
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className,
+        )}
+        {...props}
+      />
+    </div>
+  );
+}
+
+function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
+  const { orientation } = useCarousel();
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: shadcn recommends this
+    <div
+      role="group"
+      aria-roledescription="slide"
+      data-slot="carousel-item"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CarouselPrevious({
+  className,
+  variant = "outline",
+  size = "icon-sm",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+  return (
+    <Button
+      data-slot="carousel-previous"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute touch-manipulation rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -left-12 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className,
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ChevronLeftIcon className="cn-rtl-flip" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+}
+
+function CarouselNext({
+  className,
+  variant = "outline",
+  size = "icon-sm",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+  return (
+    <Button
+      data-slot="carousel-next"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute touch-manipulation rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -right-12 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className,
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ChevronRightIcon className="cn-rtl-flip" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+}
+
+export {
+  Carousel,
+  type CarouselApi,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  useCarousel,
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -928,6 +928,9 @@ importers:
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
+      embla-carousel-react:
+        specifier: ^8.6.0
+        version: 8.6.0(react@19.0.0)
       frimousse:
         specifier: ^0.3.0
         version: 0.3.0(react@19.0.0)(typescript@5.8.2)
@@ -11618,6 +11621,28 @@ packages:
       runtime-required: 1.1.0
       watchboy: 0.4.3
     dev: true
+
+  /embla-carousel-react@8.6.0(react@19.0.0):
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    dependencies:
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
+      react: 19.0.0
+    dev: false
+
+  /embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+    dependencies:
+      embla-carousel: 8.6.0
+    dev: false
+
+  /embla-carousel@8.6.0:
+    resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
+    dev: false
 
   /emmet@2.4.11:
     resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      embla-carousel-auto-height:
+        specifier: 8.6.0
+        version: 8.6.0(embla-carousel@8.6.0)
       filesize:
         specifier: ^11.0.2
         version: 11.0.2
@@ -11621,6 +11624,14 @@ packages:
       runtime-required: 1.1.0
       watchboy: 0.4.3
     dev: true
+
+  /embla-carousel-auto-height@8.6.0(embla-carousel@8.6.0):
+    resolution: {integrity: sha512-/HrJQOEM6aol/oF33gd2QlINcXy3e19fJWvHDuHWp2bpyTa+2dm9tVVJak30m2Qy6QyQ6Fc8DkImtv7pxWOJUQ==}
+    peerDependencies:
+      embla-carousel: 8.6.0
+    dependencies:
+      embla-carousel: 8.6.0
+    dev: false
 
   /embla-carousel-react@8.6.0(react@19.0.0):
     resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a rotating carousel for sidebar alerts in Desktop. Introduces a reusable `Carousel` in `@blinkdisk/ui` with auto-height, looping, and keyboard/arrow navigation.

- **New Features**
  - Desktop: `SidebarAlerts` shows Update, Offline, Trial, and Storage alerts as slides. It loops, auto-adjusts height, and includes dots plus prev/next buttons.
  - UI: Added `libs/ui/src/carousel.tsx` exporting `Carousel`, `CarouselContent`, `CarouselItem`, `CarouselNext`, and `CarouselPrevious`. Supports `orientation`, `setApi`, and arrow-key navigation.
  - Alerts: Update alert visibility now controlled by the carousel; Storage alert no longer self-hides and adds an upgrade icon.

- **Dependencies**
  - Added `embla-carousel-auto-height` in `apps/desktop`.
  - Added `embla-carousel-react` in `libs/ui`.
  - Updated `pnpm-lock.yaml`.

<sup>Written for commit 1e88c37a6a4af2730b5f7cb9dcb6d8040209a1ea. Summary will update on new commits. <a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/220?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

