### PR TITLE
fix(desktop): space update overriding trial

### DIFF
--- a/apps/desktop/src/hooks/use-space-update.ts
+++ b/apps/desktop/src/hooks/use-space-update.ts
@@ -8,7 +8,14 @@ export function useSpaceUpdate() {
 
   useEffect(() => {
     return window.electron.space.update(async (payload) => {
-      await queryClient.setQueryData(queryKeys.space, payload.space);
+      queryClient.setQueryData(queryKeys.space, (space) => {
+        if (!space) return undefined;
+
+        return {
+          ...space,
+          ...payload.space,
+        };
+      });
     });
   }, [queryClient, queryKeys]);
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents space updates from overwriting trial data in the desktop app by merging incoming updates with the cached space instead of replacing it.

- **Bug Fixes**
  - Updated `useSpaceUpdate` to merge `payload.space` into the existing cached `space` using the `setQueryData` updater, preserving fields not present in the update.

<sup>Written for commit a7a02c9f2ee17716ae39ea6abead9daf99895985. Summary will update on new commits. <a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/223?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

