### PR TITLE
feat(marketing): add kopia vulnerability analysis

### DIFF
--- a/apps/marketing/astro.config.ts
+++ b/apps/marketing/astro.config.ts
@@ -73,6 +73,14 @@ export default defineConfig({
   output: "static",
   prefetch: true,
   trailingSlash: "never",
+  markdown: {
+    shikiConfig: {
+      themes: {
+        light: "github-light",
+        dark: "github-dark",
+      },
+    },
+  },
   server: { port: 3000 },
   adapter: cloudflare({
     imageService: "compile",

--- a/apps/marketing/src/content.config.ts
+++ b/apps/marketing/src/content.config.ts
@@ -29,6 +29,46 @@ const blog = defineCollection({
     }),
 });
 
+const security = defineCollection({
+  loader: glob({ pattern: "**/*.mdx", base: "./src/content/security" }),
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    publicationDate: z.coerce.date(),
+    lastUpdated: z.coerce.date().optional(),
+    author: z.string(),
+    severity: z.string(),
+    cvssScore: z.number(),
+    cvssVector: z.string(),
+    cveId: z.string(),
+    ghsaId: z.string(),
+    credits: z.array(
+      z.object({
+        name: z.string(),
+        url: z.string().url().optional(),
+      }),
+    ),
+    references: z
+      .array(
+        z.object({
+          title: z.string(),
+          url: z.string().url(),
+        }),
+      )
+      .optional(),
+    tags: z.array(z.string()).optional(),
+    faqs: z
+      .array(
+        z.object({
+          question: z.string(),
+          answer: z.string(),
+        }),
+      )
+      .optional(),
+    draft: z.boolean().optional(),
+  }),
+});
+
 const glossary = defineCollection({
   loader: glob({ pattern: "**/*.mdx", base: "./src/content/glossary" }),
   schema: z.object({
@@ -42,4 +82,4 @@ const glossary = defineCollection({
   }),
 });
 
-export const collections = { blog, glossary };
+export const collections = { blog, security, glossary };

--- a/apps/marketing/src/content/security/CVE-2026-45695.mdx
+++ b/apps/marketing/src/content/security/CVE-2026-45695.mdx
@@ -1,0 +1,295 @@
+---
+title: "Kopia: RCE via SSH ProxyCommand Injection (CVE-2026-45695)"
+description: "Critical Kopia RCE in passwordless servers via SSH ProxyCommand injection through repository-existence checks."
+publicationDate: 2026-05-20
+author: "Paul Koeck"
+severity: "Critical"
+cvssScore: 9.8
+cvssVector: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+cveId: "CVE-2026-45695"
+ghsaId: "GHSA-2q4c-3mrw-63c3"
+credits:
+  - name: "@berardinellidaniele"
+    url: "https://github.com/berardinellidaniele"
+references:
+  - title: "GitHub Security Advisory"
+    url: "https://github.com/kopia/kopia/security/advisories/GHSA-2q4c-3mrw-63c3"
+  - title: "Patch Pull Request"
+    url: "https://github.com/kopia/kopia/pull/5354"
+---
+
+## Summary
+
+CVE-2026-45695 is a critical unauthenticated remote code execution vulnerability affecting Kopia `<= 0.22.3`.
+
+The issue appears when Kopia's passwordless HTTP server mode is combined with repository probing and the SFTP backend's support for launching an external OpenSSH process:
+
+1. Kopia HTTP server can be started with `--without-password`, causing selected UI API routes to authorize requests without credentials.
+2. The `/api/v1/repo/exists` endpoint accepts attacker-controlled repository storage configuration and passes SFTP options into `blob.NewStorage`.
+3. When SFTP storage uses `externalSSH: true`, Kopia appends user-controlled `sshArguments` directly to the OpenSSH command line.
+4. OpenSSH supports `-oProxyCommand=<cmd>`, which executes `<cmd>` through the user’s shell before any network connection is made.
+
+Put together, those behaviors give a remote unauthenticated attacker a one-request path to command execution as the Kopia server process user.
+
+## Affected Versions
+
+Affected:
+
+```text
+github.com/kopia/kopia <= 0.22.3
+```
+
+Patched:
+
+```text
+github.com/kopia/kopia >= 0.23.0
+```
+
+The advisory assigns severity `Critical`, CVSS `9.8`:
+
+```text
+CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H
+```
+
+## Root Cause
+
+### 1. Unauthenticated UI API Access
+
+In vulnerable versions, `requireUIUser` returns `true` when the server has no authenticator:
+
+```go
+func requireUIUser(_ context.Context, rc requestContext) bool {
+    if rc.srv.getAuthenticator() == nil {
+        return true
+    }
+
+    if rc.srv.getOptions().UIUser == "" {
+        return false
+    }
+
+    user, _, _ := rc.req.BasicAuth()
+
+    return user == rc.srv.getOptions().UIUser
+}
+```
+
+The vulnerable endpoint is registered as a UI route that may be called before a repository is connected:
+
+```go
+m.HandleFunc("/api/v1/repo/exists", s.handleUIPossiblyNotConnected(handleRepoExists)).Methods(http.MethodPost)
+```
+
+See [internal/server/server.go](https://github.com/kopia/kopia/blob/981d5f95ad7b64f834c46b7ac244d524644fbb46/internal/server/server.go#L146).
+
+In practice, that means a server started with `--without-password` can expose this endpoint without credentials. That matters because the endpoint does not merely read local state; it builds storage from request-supplied configuration.
+
+### 2. Attacker-Controlled Storage Configuration
+
+`handleRepoExists` unmarshals the request body into a repository-existence request, then passes the provided storage configuration directly into `blob.NewStorage`:
+
+```go
+func handleRepoExists(ctx context.Context, rc requestContext) (any, *apiError) {
+    var req serverapi.CheckRepositoryExistsRequest
+
+    if err := json.Unmarshal(rc.body, &req); err != nil {
+        return nil, unableToDecodeRequest(err)
+    }
+
+    st, err := blob.NewStorage(ctx, req.Storage, false)
+    if err != nil {
+        return nil, internalServerError(err)
+    }
+
+    defer st.Close(ctx)
+    ...
+}
+```
+
+See [internal/server/api_repo.go](https://github.com/kopia/kopia/blob/981d5f95ad7b64f834c46b7ac244d524644fbb46/internal/server/api_repo.go#L151).
+
+This is the important boundary crossing. The attacker does not need an existing Kopia repository, nor do they need to influence a saved server-side configuration. They can provide a fresh storage configuration directly in the HTTP request and cause Kopia to instantiate it.
+
+### 3. SFTP `externalSSH` Command Construction
+
+The SFTP options include externally controlled fields:
+
+```go
+ExternalSSH  bool   `json:"externalSSH"`
+SSHCommand   string `json:"sshCommand,omitempty"`
+SSHArguments string `json:"sshArguments,omitempty"`
+```
+
+See [repo/blob/sftp/sftp_options.go](https://github.com/kopia/kopia/blob/981d5f95ad7b64f834c46b7ac244d524644fbb46/repo/blob/sftp/sftp_options.go#L27).
+
+When `externalSSH` is enabled, Kopia builds the external SSH process arguments like this:
+
+```go
+if opt.SSHArguments != "" {
+    cmdArgs = append(cmdArgs, strings.Split(opt.SSHArguments, " ")...)
+}
+
+cmdArgs = append(
+    cmdArgs,
+    opt.Username+"@"+opt.Host,
+    "-s", "sftp",
+)
+
+sshCommand := opt.SSHCommand
+if sshCommand == "" {
+    sshCommand = "ssh"
+}
+
+cmd := exec.CommandContext(ctx, sshCommand, cmdArgs...)
+```
+
+See [repo/blob/sftp/sftp_storage.go](https://github.com/kopia/kopia/blob/981d5f95ad7b64f834c46b7ac244d524644fbb46/repo/blob/sftp/sftp_storage.go#L450).
+
+The use of `exec.CommandContext` avoids the most obvious form of shell injection in Kopia itself. Kopia is not building a command string and handing it to `sh -c`.
+
+The problem is one layer lower: Kopia gives the attacker control over OpenSSH options, and OpenSSH has options whose documented behavior includes executing a local command.
+
+The dangerous option is:
+
+```text
+-oProxyCommand=<command>
+```
+
+OpenSSH executes the proxy command via the user's shell and then runs the SSH transport over that command's standard input/output. This happens before SSH needs a successful connection to the configured host, so the host in the request can be effectively irrelevant.
+
+## Exploit Chain
+
+The exploit path is short. An attacker needs a Kopia server running a vulnerable version, exposed over HTTP, and started in passwordless mode. From there, the request targets `/api/v1/repo/exists` with an SFTP storage configuration that enables `externalSSH` and supplies a malicious OpenSSH option.
+
+The full set of required conditions is:
+
+1. Kopia server is running a vulnerable version, `<= 0.22.3`.
+2. The server was started with `--without-password`.
+3. The server is reachable by the attacker over HTTP.
+4. The attacker sends a POST request to `/api/v1/repo/exists`.
+5. The JSON body specifies SFTP storage with `externalSSH: true`.
+6. The JSON body includes `sshArguments` containing an OpenSSH `ProxyCommand`.
+
+When the endpoint calls `blob.NewStorage`, Kopia instantiates the SFTP storage backend. That backend launches `ssh`; `ssh` parses `ProxyCommand`; and the proxy command runs attacker-controlled shell code.
+
+## Impact
+
+The direct impact is arbitrary code execution as the Kopia server process user.
+
+Potential consequences include:
+
+- Reading repository configuration and local files accessible to the Kopia process.
+- Exfiltrating repository credentials, tokens, SSH keys, or environment variables.
+- Modifying or deleting repository data.
+- Running arbitrary local commands.
+- Installing persistence under the compromised user account.
+- Using the host as a pivot point into internal networks.
+- Denial of service by killing the Kopia process or exhausting resources.
+
+## CWE Mapping
+
+CWE-78: Improper Neutralization of Special Elements used in an OS Command
+
+CWE-306: Missing Authentication for Critical Function
+
+## Why `exec.CommandContext` Was Not Sufficient
+
+`exec.CommandContext("ssh", args...)` protects against shell metacharacters being interpreted by Kopia’s shell, because Kopia does not invoke a shell directly.
+
+However, it does not protect against dangerous options in the invoked program.
+
+For example, these are materially different risks:
+
+```text
+; rm -rf /      # shell metacharacter injection into the parent shell
+-oProxyCommand # legitimate ssh option that causes ssh to invoke a shell
+```
+
+The vulnerable code defended against the first category but allowed the second.
+
+This is a common trap: treating "argv-safe" process spawning as equivalent to safe command execution. It is only safe when the invoked program's argument grammar is safe for untrusted input, or when dangerous features in that grammar are explicitly blocked.
+
+## Mitigation Analysis
+
+[PR #5354](https://github.com/kopia/kopia/pull/5354) mitigates the reported remote unauthenticated attack by preventing passwordless insecure servers from listening on non-loopback interfaces by default.
+
+The new validation is in [internal/insecureserverbind/insecureserverbind.go](https://github.com/kopia/kopia/blob/981d5f95ad7b64f834c46b7ac244d524644fbb46/internal/insecureserverbind/insecureserverbind.go#L22).
+
+The restriction applies only when all of these are true:
+
+```go
+return insecure && withoutPassword && !allowDangerousNetwork
+```
+
+Before server startup, Kopia now validates the configured listen address:
+
+```go
+if err := insecureserverbind.ValidateListenAddressIfRestricted(
+    c.serverStartInsecure,
+    c.serverStartWithoutPassword,
+    c.serverStartAllowDangerousUnauthenticatedNetwork,
+    c.sf.serverAddress,
+); err != nil {
+    return errors.Wrap(err, "listen address not allowed for insecure server without password")
+}
+```
+
+See [cli/command_server_start.go](https://github.com/kopia/kopia/blob/981d5f95ad7b64f834c46b7ac244d524644fbb46/cli/command_server_start.go#L199).
+
+It also validates the actual bound listener after `Listen`, which matters for systemd socket activation or cases where the configured address does not fully represent the actual socket:
+
+```go
+if err := insecureserverbind.ValidateListenerAddrIfRestricted(
+    c.serverStartInsecure,
+    c.serverStartWithoutPassword,
+    c.serverStartAllowDangerousUnauthenticatedNetwork,
+    l.Addr(),
+); err != nil {
+    l.Close()
+    return errors.Wrap(err, "insecure server bind validation")
+}
+```
+
+See [cli/command_server_tls.go](https://github.com/kopia/kopia/blob/981d5f95ad7b64f834c46b7ac244d524644fbb46/cli/command_server_tls.go#L66).
+
+Allowed unauthenticated binds include:
+
+```text
+127.0.0.0/8 loopback
+::1 loopback
+localhost
+Unix domain sockets
+```
+
+Rejected binds include:
+
+```text
+0.0.0.0
+[::]
+empty host / all interfaces
+non-loopback IPs
+non-localhost hostnames
+```
+
+There is also an explicit hidden override:
+
+```text
+--allow-extremely-dangerous-unauthenticated-server-on-the-network
+```
+
+That preserves the old behavior for operators who explicitly opt into the risk, while changing the default away from a remotely reachable unauthenticated server.
+
+## Recommended Remediation
+
+The primary remediation is straightforward:
+
+```text
+Upgrade Kopia to >= 0.23.0.
+```
+
+Operators should also treat passwordless server mode as local-only:
+
+- Do not run Kopia server with --without-password on any network-accessible interface.
+- Bind passwordless servers only to 127.0.0.1, ::1, localhost, or a Unix socket.
+- Avoid using the dangerous override flag except in isolated test environments.
+- Require authentication for UI/API access.
+- Place Kopia behind a trusted reverse proxy only if authentication and network ACLs are correctly enforced.

--- a/apps/marketing/src/layouts/SecurityAnalysisLayout.astro
+++ b/apps/marketing/src/layouts/SecurityAnalysisLayout.astro
@@ -1,7 +1,7 @@
 ---
+import { MARKETING_URL } from "astro:env/server";
 import ArrowUpRightIcon from "@lucide/astro/icons/arrow-up-right";
 import ShieldAlertIcon from "@lucide/astro/icons/shield-alert";
-import { MARKETING_URL } from "astro:env/server";
 import Github from "@marketing/components/icons/Github.astro";
 import Logo from "@marketing/components/icons/Logo.astro";
 import TableOfContents from "@marketing/components/TableOfContents.astro";

--- a/apps/marketing/src/layouts/SecurityAnalysisLayout.astro
+++ b/apps/marketing/src/layouts/SecurityAnalysisLayout.astro
@@ -1,0 +1,534 @@
+---
+import ArrowUpRightIcon from "@lucide/astro/icons/arrow-up-right";
+import ShieldAlertIcon from "@lucide/astro/icons/shield-alert";
+import { MARKETING_URL } from "astro:env/server";
+import Github from "@marketing/components/icons/Github.astro";
+import Logo from "@marketing/components/icons/Logo.astro";
+import TableOfContents from "@marketing/components/TableOfContents.astro";
+import BaseLayout from "@marketing/layouts/BaseLayout.astro";
+
+type Heading = {
+  depth: number;
+  slug: string;
+  text: string;
+};
+
+type Props = {
+  title: string;
+  description: string;
+  publicationDate: Date;
+  lastUpdated?: Date;
+  author: string;
+  severity: string;
+  cvssScore: number;
+  cvssVector: string;
+  cveId: string;
+  ghsaId: string;
+  credits: {
+    name: string;
+    url?: string;
+  }[];
+  references?: {
+    title: string;
+    url: string;
+  }[];
+  headings: Heading[];
+  structuredData?: Record<string, unknown> | Record<string, unknown>[];
+};
+
+const {
+  title,
+  description,
+  publicationDate,
+  lastUpdated,
+  author,
+  severity,
+  cvssScore,
+  cvssVector,
+  cveId,
+  ghsaId,
+  credits,
+  references,
+  headings,
+  structuredData,
+} = Astro.props;
+
+const siteUrl = MARKETING_URL ?? "https://blinkdisk.com";
+const updatedDate = lastUpdated ?? publicationDate;
+
+const formatDate = (date: Date) =>
+  date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+
+const formattedPublicationDate = formatDate(publicationDate);
+const formattedUpdatedDate = formatDate(updatedDate);
+const wasUpdated = updatedDate.getTime() !== publicationDate.getTime();
+const normalizedSeverity = severity.toLowerCase();
+
+type SeverityTheme = {
+  badge: string;
+  dot: string;
+  accent: string;
+  ring: string;
+};
+
+const severityTheme: SeverityTheme = (() => {
+  switch (normalizedSeverity) {
+    case "critical":
+      return {
+        badge:
+          "border-red-500/40 bg-red-500/10 text-red-700 dark:bg-red-500/15 dark:text-red-300",
+        dot: "bg-red-500 shadow-[0_0_0_4px_rgba(239,68,68,0.18)]",
+        accent: "bg-red-500/70",
+        ring: "ring-red-500/20",
+      };
+    case "high":
+      return {
+        badge:
+          "border-orange-500/40 bg-orange-500/10 text-orange-700 dark:bg-orange-500/15 dark:text-orange-300",
+        dot: "bg-orange-500 shadow-[0_0_0_4px_rgba(249,115,22,0.18)]",
+        accent: "bg-orange-500/70",
+        ring: "ring-orange-500/20",
+      };
+    case "medium":
+      return {
+        badge:
+          "border-yellow-500/40 bg-yellow-500/10 text-yellow-800 dark:bg-yellow-500/15 dark:text-yellow-300",
+        dot: "bg-yellow-500 shadow-[0_0_0_4px_rgba(234,179,8,0.18)]",
+        accent: "bg-yellow-500/70",
+        ring: "ring-yellow-500/20",
+      };
+    case "low":
+      return {
+        badge:
+          "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300",
+        dot: "bg-emerald-500 shadow-[0_0_0_4px_rgba(16,185,129,0.18)]",
+        accent: "bg-emerald-500/70",
+        ring: "ring-emerald-500/20",
+      };
+    default:
+      return {
+        badge: "border-border bg-secondary/70 text-foreground",
+        dot: "bg-foreground/40",
+        accent: "bg-foreground/40",
+        ring: "ring-border",
+      };
+  }
+})();
+
+const cvssMetrics: Record<
+  string,
+  { label: string; values: Record<string, string> }
+> = {
+  AV: {
+    label: "Attack vector",
+    values: { N: "Network", A: "Adjacent", L: "Local", P: "Physical" },
+  },
+  AC: {
+    label: "Attack complexity",
+    values: { L: "Low", H: "High" },
+  },
+  PR: {
+    label: "Privileges required",
+    values: { N: "None", L: "Low", H: "High" },
+  },
+  UI: {
+    label: "User interaction",
+    values: { N: "None", R: "Required" },
+  },
+  S: {
+    label: "Scope",
+    values: { U: "Unchanged", C: "Changed" },
+  },
+  C: {
+    label: "Confidentiality",
+    values: { N: "None", L: "Low", H: "High" },
+  },
+  I: {
+    label: "Integrity",
+    values: { N: "None", L: "Low", H: "High" },
+  },
+  A: {
+    label: "Availability",
+    values: { N: "None", L: "Low", H: "High" },
+  },
+};
+
+const parsedMetrics = cvssVector
+  .split("/")
+  .map((part) => {
+    const [key, raw] = part.split(":");
+    const metric = cvssMetrics[key];
+    if (!metric || !raw) return null;
+    return {
+      label: metric.label,
+      value: metric.values[raw] ?? raw,
+      emphasis: raw === "H" || (key === "PR" && raw === "N"),
+    };
+  })
+  .filter((m): m is { label: string; value: string; emphasis: boolean } =>
+    Boolean(m),
+  );
+
+const cvssVersionMatch = cvssVector.match(/^CVSS:([\d.]+)/i);
+const cvssVersion = cvssVersionMatch ? `CVSS ${cvssVersionMatch[1]}` : "CVSS";
+
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  headline: title,
+  description: description,
+  datePublished: publicationDate.toISOString(),
+  dateModified: updatedDate.toISOString(),
+  author: {
+    "@type": "Person",
+    name: author,
+  },
+  publisher: {
+    "@type": "Organization",
+    name: "BlinkDisk",
+    url: siteUrl,
+  },
+  identifier: [cveId, ghsaId],
+};
+
+const pageStructuredData = [
+  articleSchema,
+  ...(Array.isArray(structuredData)
+    ? structuredData
+    : structuredData
+      ? [structuredData]
+      : []),
+];
+---
+
+<BaseLayout
+  title={title}
+  description={description}
+  og={{ title }}
+  structuredData={pageStructuredData}
+>
+  <nav
+    class="border-border/60 bg-background/85 sticky top-0 z-30 border-b backdrop-blur-md"
+  >
+    <div
+      class="mx-auto flex h-16 w-[90vw] max-w-5xl items-center justify-between"
+    >
+      <div class="flex min-w-0 items-center gap-3">
+        <a
+          href="/"
+          aria-label="BlinkDisk"
+          data-astro-prefetch
+          class="shrink-0"
+        >
+          <Logo class="h-5 select-none sm:h-6" />
+        </a>
+        <span class="text-border" aria-hidden="true">/</span>
+        <p
+          class="text-foreground/80 inline-flex items-center gap-1.5 text-sm font-medium"
+        >
+          Security
+        </p>
+        <span class="text-border" aria-hidden="true">/</span>
+        <p
+          class="text-foreground/80 inline-flex items-center gap-1.5 text-sm font-medium"
+        >
+          Analysis
+        </p>
+      </div>
+      <a
+        href="https://github.com/blinkdisk/blinkdisk"
+        class="text-foreground/70 hover:text-foreground inline-flex items-center gap-2 text-sm font-medium transition-colors"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <Github class="size-4" />
+        <span class="hidden sm:inline">GitHub</span>
+      </a>
+    </div>
+  </nav>
+
+  <main>
+    <article
+      class="mx-auto w-[90vw] max-w-3xl pt-16 lg:max-w-5xl lg:pt-24"
+    >
+      <header class="mb-14">
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <span
+            class:list={[
+              "inline-flex items-center gap-2 rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wider",
+              severityTheme.badge,
+            ]}
+          >
+            <span
+              class:list={["size-1.5 rounded-full", severityTheme.dot]}
+              aria-hidden="true"
+            ></span>
+            {severity} severity
+          </span>
+          <span class="text-border" aria-hidden="true">·</span>
+          <span class="text-muted-foreground font-mono text-xs sm:text-sm">
+            {cveId}
+          </span>
+        </div>
+
+        <h1
+          class="text-foreground mt-6 text-balance text-3xl font-bold leading-tight tracking-tight md:text-4xl lg:text-5xl"
+        >
+          {title}
+        </h1>
+
+        <p
+          class="text-muted-foreground mt-5 max-w-2xl text-balance text-base leading-relaxed md:text-lg"
+        >
+          {description}
+        </p>
+
+        <div
+          class="text-muted-foreground mt-8 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm"
+        >
+          <span>
+            By <span class="text-foreground font-medium">{author}</span>
+          </span>
+          <span aria-hidden="true">·</span>
+          <span>
+            Published <time datetime={publicationDate.toISOString()}
+              >{formattedPublicationDate}</time
+            >
+          </span>
+          {
+            wasUpdated && (
+              <>
+                <span aria-hidden="true">·</span>
+                <span>
+                  Updated{" "}
+                  <time datetime={updatedDate.toISOString()}>
+                    {formattedUpdatedDate}
+                  </time>
+                </span>
+              </>
+            )
+          }
+        </div>
+
+        <section
+          aria-labelledby="advisory-overview-heading"
+          class="bg-card border-border/80 ring-border/40 mt-10 overflow-hidden rounded-2xl border shadow-sm ring-1"
+        >
+          <div class="grid lg:grid-cols-[20rem_1fr]">
+            <div
+              class="border-border/60 relative flex flex-col gap-5 border-b p-6 lg:border-b-0 lg:border-r"
+            >
+              <div
+                class:list={[
+                  "absolute left-0 top-0 h-full w-1",
+                  severityTheme.accent,
+                ]}
+                aria-hidden="true"
+              >
+              </div>
+              <div class="flex items-center justify-between">
+                <p
+                  id="advisory-overview-heading"
+                  class="text-muted-foreground text-xs font-semibold uppercase tracking-[0.15em]"
+                >
+                  Severity score
+                </p>
+                <span class="text-muted-foreground font-mono text-[10px] uppercase tracking-wider">
+                  {cvssVersion}
+                </span>
+              </div>
+              <div class="flex items-baseline gap-2">
+                <span
+                  class:list={[
+                    "text-6xl font-bold leading-none tracking-tight tabular-nums",
+                  ]}
+                >
+                  {cvssScore}
+                </span>
+                <span class="text-muted-foreground text-sm font-medium">
+                  / 10
+                </span>
+              </div>
+              <dl class="border-border/60 flex flex-col gap-3 border-t pt-5">
+                <div class="flex items-baseline justify-between gap-3">
+                  <dt
+                    class="text-muted-foreground text-[11px] font-medium uppercase tracking-wider"
+                  >
+                    CVE
+                  </dt>
+                  <dd
+                    class="text-foreground break-all text-right font-mono text-sm font-semibold"
+                  >
+                    {cveId}
+                  </dd>
+                </div>
+                <div class="flex items-baseline justify-between gap-3">
+                  <dt
+                    class="text-muted-foreground text-[11px] font-medium uppercase tracking-wider"
+                  >
+                    GHSA
+                  </dt>
+                  <dd
+                    class="text-foreground break-all text-right font-mono text-sm font-semibold"
+                  >
+                    {ghsaId}
+                  </dd>
+                </div>
+              </dl>
+            </div>
+
+            <div class="flex flex-col">
+              {
+                parsedMetrics.length > 0 && (
+                  <dl class="bg-border/50 grid gap-px sm:grid-cols-2 lg:grid-cols-4">
+                    {parsedMetrics.map((metric) => (
+                      <div class="bg-card flex flex-col gap-1.5 p-4">
+                        <dt class="text-muted-foreground text-[11px] font-medium uppercase tracking-wider">
+                          {metric.label}
+                        </dt>
+                        <dd
+                          class:list={[
+                            "text-sm font-semibold",
+                            metric.emphasis
+                              ? "text-red-500 dark:text-red-400"
+                              : "text-foreground",
+                          ]}
+                        >
+                          {metric.value}
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                )
+              }
+              <div
+                class="border-border/60 flex flex-col gap-2 border-t p-6"
+              >
+                <p
+                  class="text-muted-foreground text-[11px] font-medium uppercase tracking-wider"
+                >
+                  CVSS vector
+                </p>
+                <code
+                  class="bg-secondary/60 border-border/70 text-foreground/85 block break-all rounded-md border px-3 py-2 font-mono text-xs"
+                >
+                  {cvssVector}
+                </code>
+              </div>
+              <div
+                class="border-border/60 flex flex-col gap-3 border-t p-6 sm:flex-row sm:items-center sm:justify-between"
+              >
+                <p
+                  class="text-muted-foreground text-[11px] font-medium uppercase tracking-wider"
+                >
+                  Credits
+                </p>
+                <div class="flex flex-wrap gap-2">
+                  {
+                    credits.map((credit) =>
+                      credit.url ? (
+                        <a
+                          href={credit.url}
+                          class="border-border/70 bg-secondary/40 text-foreground hover:border-primary/40 hover:text-primary inline-flex items-center gap-1.5 rounded-full border px-3 py-1 font-mono text-xs transition-colors"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {credit.name}
+                          <ArrowUpRightIcon class="size-3 opacity-60" />
+                        </a>
+                      ) : (
+                        <span class="border-border/70 bg-secondary/40 text-foreground inline-flex items-center rounded-full border px-3 py-1 font-mono text-xs">
+                          {credit.name}
+                        </span>
+                      ),
+                    )
+                  }
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </header>
+
+      <div class="flex flex-col gap-12 lg:flex-row lg:gap-16">
+        <div
+          class="prose dark:prose-invert prose-img:rounded-xl prose-img:shadow prose-headings:scroll-mt-24 prose-headings:tracking-tight prose-h2:mt-12 prose-h2:first-of-type:mt-0 prose-h2:border-b prose-h2:border-border/60 prose-h2:pb-3 min-w-0 max-w-none flex-1"
+        >
+          <slot />
+          {
+            references?.length ? (
+              <section class="not-prose mt-16">
+                <div class="flex items-baseline justify-between gap-4">
+                  <h2 class="text-foreground text-2xl font-semibold tracking-tight">
+                    References
+                  </h2>
+                  <span class="text-muted-foreground text-xs uppercase tracking-wider">
+                    {references.length} source{references.length === 1 ? "" : "s"}
+                  </span>
+                </div>
+                <ul class="mt-6 grid gap-3 sm:grid-cols-2">
+                  {references.map((reference) => (
+                    <li>
+                      <a
+                        href={reference.url}
+                        class="group bg-card border-border/70 hover:border-primary/40 hover:bg-card-hover relative flex h-full flex-col gap-2 rounded-xl border p-4 transition-all"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        <div class="flex items-start justify-between gap-3">
+                          <span class="text-foreground group-hover:text-primary text-sm font-medium leading-snug transition-colors">
+                            {reference.title}
+                          </span>
+                          <ArrowUpRightIcon class="text-muted-foreground group-hover:text-primary mt-0.5 size-4 shrink-0 transition-all group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+                        </div>
+                        <span class="text-muted-foreground break-all font-mono text-xs">
+                          {reference.url.replace(/^https?:\/\//, "")}
+                        </span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null
+          }
+        </div>
+        <aside class="hidden w-56 shrink-0 lg:block">
+          <div class="sticky top-24">
+            <TableOfContents headings={headings} />
+          </div>
+        </aside>
+      </div>
+    </article>
+  </main>
+
+  <footer class="border-border/60 mt-16 border-t">
+    <div
+      class="text-muted-foreground mx-auto flex w-[90vw] max-w-5xl flex-col items-center gap-4 py-10 text-center text-sm sm:flex-row sm:justify-between sm:text-left"
+    >
+      <div class="flex items-center gap-3">
+        <a href="/" aria-label="BlinkDisk" data-astro-prefetch>
+          <Logo class="text-foreground h-5 select-none" />
+        </a>
+        <span>&copy; {new Date().getFullYear()} BlinkDisk</span>
+      </div>
+      <nav
+        class="flex flex-wrap justify-center gap-x-5 gap-y-2 sm:justify-start"
+        aria-label="Legal"
+      >
+        <a href="/privacy" class="hover:text-foreground transition-colors">
+          Privacy
+        </a>
+        <a href="/terms" class="hover:text-foreground transition-colors">
+          Terms
+        </a>
+        <a href="/imprint" class="hover:text-foreground transition-colors">
+          Imprint
+        </a>
+      </nav>
+    </div>
+  </footer>
+</BaseLayout>

--- a/apps/marketing/src/layouts/SecurityAnalysisLayout.astro
+++ b/apps/marketing/src/layouts/SecurityAnalysisLayout.astro
@@ -14,6 +14,7 @@ type Heading = {
 };
 
 type Props = {
+  slug: string;
   title: string;
   description: string;
   publicationDate: Date;
@@ -37,6 +38,7 @@ type Props = {
 };
 
 const {
+  slug,
   title,
   description,
   publicationDate,
@@ -55,6 +57,7 @@ const {
 
 const siteUrl = MARKETING_URL ?? "https://blinkdisk.com";
 const updatedDate = lastUpdated ?? publicationDate;
+const ogImage = `/security/analysis/og/${slug}.png`;
 
 const formatDate = (date: Date) =>
   date.toLocaleDateString("en-US", {
@@ -208,7 +211,7 @@ const pageStructuredData = [
 <BaseLayout
   title={title}
   description={description}
-  og={{ title }}
+  og={{ title, image: ogImage }}
   structuredData={pageStructuredData}
 >
   <nav

--- a/apps/marketing/src/pages/security/analysis/[slug].astro
+++ b/apps/marketing/src/pages/security/analysis/[slug].astro
@@ -1,0 +1,52 @@
+---
+import { getCollection, render } from "astro:content";
+import SecurityAnalysisLayout from "@marketing/layouts/SecurityAnalysisLayout.astro";
+
+export async function getStaticPaths() {
+  const analyses = await getCollection("security", ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+  });
+
+  return analyses.map((analysis) => ({
+    params: { slug: analysis.id },
+    props: { analysis },
+  }));
+}
+
+const { analysis } = Astro.props;
+const { Content, headings } = await render(analysis);
+
+const faqStructuredData = analysis.data.faqs?.length
+  ? {
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      mainEntity: analysis.data.faqs.map((faq) => ({
+        "@type": "Question",
+        name: faq.question,
+        acceptedAnswer: {
+          "@type": "Answer",
+          text: faq.answer,
+        },
+      })),
+    }
+  : undefined;
+---
+
+<SecurityAnalysisLayout
+  title={analysis.data.title}
+  description={analysis.data.description}
+  publicationDate={analysis.data.publicationDate}
+  lastUpdated={analysis.data.lastUpdated}
+  author={analysis.data.author}
+  severity={analysis.data.severity}
+  cvssScore={analysis.data.cvssScore}
+  cvssVector={analysis.data.cvssVector}
+  cveId={analysis.data.cveId}
+  ghsaId={analysis.data.ghsaId}
+  credits={analysis.data.credits}
+  references={analysis.data.references}
+  headings={headings}
+  structuredData={faqStructuredData}
+>
+  <Content />
+</SecurityAnalysisLayout>

--- a/apps/marketing/src/pages/security/analysis/[slug].astro
+++ b/apps/marketing/src/pages/security/analysis/[slug].astro
@@ -33,6 +33,7 @@ const faqStructuredData = analysis.data.faqs?.length
 ---
 
 <SecurityAnalysisLayout
+  slug={analysis.id}
   title={analysis.data.title}
   description={analysis.data.description}
   publicationDate={analysis.data.publicationDate}

--- a/apps/marketing/src/pages/security/analysis/og/[slug].png.ts
+++ b/apps/marketing/src/pages/security/analysis/og/[slug].png.ts
@@ -1,0 +1,45 @@
+import { getCollection } from "astro:content";
+import {
+  createOgImageResponse,
+  generateSecurityAnalysisOgImage,
+} from "@marketing/utils/og-image";
+import type { APIRoute, GetStaticPaths } from "astro";
+
+type SecurityAnalysisOgProps = {
+  title: string;
+  description: string;
+  severity: string;
+  cvssScore: number;
+  cveId: string;
+};
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const analyses = await getCollection("security", ({ data }) => {
+    return import.meta.env.PROD ? data.draft !== true : true;
+  });
+
+  return analyses.map((analysis) => ({
+    params: { slug: analysis.id },
+    props: {
+      title: analysis.data.title,
+      description: analysis.data.description,
+      severity: analysis.data.severity,
+      cvssScore: analysis.data.cvssScore,
+      cveId: analysis.data.cveId,
+    } satisfies SecurityAnalysisOgProps,
+  }));
+};
+
+export const GET: APIRoute = async ({ props }) => {
+  const { title, description, severity, cvssScore, cveId } =
+    props as SecurityAnalysisOgProps;
+
+  const png = await generateSecurityAnalysisOgImage({
+    title,
+    description,
+    severity,
+    cvssScore,
+    cveId,
+  });
+  return createOgImageResponse(png);
+};

--- a/apps/marketing/src/styles.css
+++ b/apps/marketing/src/styles.css
@@ -42,6 +42,22 @@ body:has([class~="sticky"], [class*=":sticky"]) {
   scroll-margin-top: 8rem;
 }
 
+.astro-code,
+.astro-code span {
+  background-color: var(--color-card) !important;
+}
+
+.dark .astro-code,
+.dark .astro-code span {
+  background-color: var(--color-card) !important;
+  /*background-color: var(--shiki-dark-bg) !important;*/
+
+  color: var(--shiki-dark) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
 @font-face {
   font-family: Inter;
   font-style: normal;

--- a/apps/marketing/src/utils/og-image.ts
+++ b/apps/marketing/src/utils/og-image.ts
@@ -30,6 +30,44 @@ type OgImageOptions = {
   badge?: string;
 };
 
+type SecurityAnalysisOgImageOptions = {
+  title: string;
+  description: string;
+  severity: string;
+  cvssScore: number;
+  cveId: string;
+};
+
+const severityColors: Record<
+  string,
+  { primary: string; soft: string; text: string; border: string }
+> = {
+  critical: {
+    primary: "#ef4444",
+    soft: "rgba(239, 68, 68, 0.16)",
+    text: "#fecaca",
+    border: "rgba(239, 68, 68, 0.45)",
+  },
+  high: {
+    primary: "#f97316",
+    soft: "rgba(249, 115, 22, 0.16)",
+    text: "#fed7aa",
+    border: "rgba(249, 115, 22, 0.45)",
+  },
+  medium: {
+    primary: "#eab308",
+    soft: "rgba(234, 179, 8, 0.16)",
+    text: "#fef08a",
+    border: "rgba(234, 179, 8, 0.45)",
+  },
+  low: {
+    primary: "#10b981",
+    soft: "rgba(16, 185, 129, 0.16)",
+    text: "#a7f3d0",
+    border: "rgba(16, 185, 129, 0.45)",
+  },
+};
+
 export async function generateOgImage({
   title,
   description,
@@ -129,6 +167,263 @@ export async function generateOgImage({
                     lineHeight: 1.5,
                   },
                   children: truncatedDescription,
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+  };
+
+  const svg = await satori(element as ReactNode, {
+    width: 1200,
+    height: 630,
+    fonts: [
+      {
+        name: "Inter",
+        data: inter400,
+        weight: 400,
+        style: "normal",
+      },
+      {
+        name: "Inter",
+        data: inter700,
+        weight: 700,
+        style: "normal",
+      },
+    ],
+  });
+
+  return sharp(Buffer.from(svg)).png().toBuffer();
+}
+
+export async function generateSecurityAnalysisOgImage({
+  title,
+  description,
+  severity,
+  cvssScore,
+  cveId,
+}: SecurityAnalysisOgImageOptions): Promise<Buffer> {
+  const normalizedSeverity = severity.toLowerCase();
+  const theme = severityColors[normalizedSeverity] ?? {
+    primary: "#94a3b8",
+    soft: "rgba(148, 163, 184, 0.16)",
+    text: "#cbd5e1",
+    border: "rgba(148, 163, 184, 0.4)",
+  };
+  const truncatedDescription =
+    description.length > 145 ? `${description.slice(0, 142)}...` : description;
+  const titleSize = title.length > 68 ? 46 : title.length > 52 ? 50 : 56;
+  const score = Number.isInteger(cvssScore)
+    ? cvssScore.toFixed(1)
+    : String(cvssScore);
+
+  const logoElement = {
+    type: "img",
+    props: {
+      src: logoDataUri,
+      width: 220,
+      height: 33,
+      style: {
+        height: "33px",
+      },
+    },
+  };
+
+  const element = {
+    type: "div",
+    props: {
+      style: {
+        height: "100%",
+        width: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        padding: "56px 60px",
+        background:
+          "linear-gradient(135deg, #08090b 0%, #101318 48%, #171014 100%)",
+        color: "#ffffff",
+        fontFamily: "Inter",
+        position: "relative",
+      },
+      children: [
+        {
+          type: "div",
+          props: {
+            style: {
+              position: "absolute",
+              top: 0,
+              right: 0,
+              width: "430px",
+              height: "430px",
+              background: `radial-gradient(circle, ${theme.soft} 0%, rgba(0, 0, 0, 0) 68%)`,
+            },
+          },
+        },
+        {
+          type: "div",
+          props: {
+            style: {
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              width: "100%",
+            },
+            children: [
+              logoElement,
+              {
+                type: "div",
+                props: {
+                  style: {
+                    display: "flex",
+                    alignItems: "center",
+                    gap: "12px",
+                    backgroundColor: theme.soft,
+                    border: `1px solid ${theme.border}`,
+                    color: theme.text,
+                    fontSize: "19px",
+                    fontWeight: 700,
+                    padding: "10px 18px",
+                    borderRadius: "9999px",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                  },
+                  children: [
+                    {
+                      type: "div",
+                      props: {
+                        style: {
+                          width: "10px",
+                          height: "10px",
+                          borderRadius: "9999px",
+                          backgroundColor: theme.primary,
+                        },
+                      },
+                    },
+                    `${severity} severity`,
+                  ],
+                },
+              },
+            ],
+          },
+        },
+        {
+          type: "div",
+          props: {
+            style: {
+              display: "flex",
+              gap: "46px",
+              alignItems: "flex-end",
+              width: "100%",
+            },
+            children: [
+              {
+                type: "div",
+                props: {
+                  style: {
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "24px",
+                    flex: "1 1 auto",
+                  },
+                  children: [
+                    {
+                      type: "div",
+                      props: {
+                        style: {
+                          display: "flex",
+                          gap: "14px",
+                          color: "rgba(255, 255, 255, 0.62)",
+                          fontSize: "22px",
+                          fontFamily: "Inter",
+                        },
+                        children: cveId,
+                      },
+                    },
+                    {
+                      type: "div",
+                      props: {
+                        style: {
+                          color: "#ffffff",
+                          fontSize: `${titleSize}px`,
+                          fontWeight: 700,
+                          lineHeight: 1.12,
+                          maxWidth: "800px",
+                        },
+                        children: title,
+                      },
+                    },
+                    {
+                      type: "div",
+                      props: {
+                        style: {
+                          color: "rgba(255, 255, 255, 0.7)",
+                          fontSize: "25px",
+                          lineHeight: 1.45,
+                          maxWidth: "760px",
+                        },
+                        children: truncatedDescription,
+                      },
+                    },
+                  ],
+                },
+              },
+              {
+                type: "div",
+                props: {
+                  style: {
+                    width: "210px",
+                    height: "210px",
+                    flexShrink: 0,
+                    borderRadius: "28px",
+                    border: `1px solid ${theme.border}`,
+                    backgroundColor: "rgba(255, 255, 255, 0.045)",
+                    display: "flex",
+                    flexDirection: "column",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    gap: "10px",
+                    boxShadow: `inset 0 0 0 1px rgba(255, 255, 255, 0.04), 0 0 60px ${theme.soft}`,
+                  },
+                  children: [
+                    {
+                      type: "div",
+                      props: {
+                        style: {
+                          color: "rgba(255, 255, 255, 0.6)",
+                          fontSize: "18px",
+                          fontWeight: 700,
+                          textTransform: "uppercase",
+                          letterSpacing: "0.12em",
+                        },
+                        children: "CVSS",
+                      },
+                    },
+                    {
+                      type: "div",
+                      props: {
+                        style: {
+                          color: "#ffffff",
+                          fontSize: "76px",
+                          fontWeight: 700,
+                          lineHeight: 1,
+                        },
+                        children: score,
+                      },
+                    },
+                    {
+                      type: "div",
+                      props: {
+                        style: {
+                          color: theme.text,
+                          fontSize: "20px",
+                          fontWeight: 700,
+                        },
+                        children: "/ 10",
+                      },
+                    },
+                  ],
                 },
               },
             ],


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Security Analysis section to the marketing site with a dedicated layout and route for publishing CVE write-ups. Launches with a detailed analysis of Kopia RCE (CVE-2026-45695) and severity-themed OG images.

- New Features
  - Added `security` content collection (schema: severity, CVSS, CVE/GHSA, credits, references, FAQs, draft).
  - New `SecurityAnalysisLayout.astro` with CVSS parsing, severity theming, TOC, credits, references, and Schema.org `TechArticle`/`FAQPage`.
  - Page at `security/analysis/[slug]` renders MDX via `astro:content`; builds static paths; excludes drafts in prod.
  - Initial post `CVE-2026-45695.mdx`.
  - New OG image generator and route `security/analysis/og/[slug].png.ts` using `satori` + `sharp`; images show severity, CVSS, and CVE.
  - Enabled Shiki code theming in `astro.config.ts` (github-light/dark) and refined code block styles.

<sup>Written for commit 9b16a510e246f97d18924a7cfe920c14f368dc30. Summary will update on new commits. <a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/224?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

