### PR TITLE
feat(desktop): add alternativeto review alert

### DIFF
--- a/apps/desktop/src/components/sidebar/alerts.tsx
+++ b/apps/desktop/src/components/sidebar/alerts.tsx
@@ -7,14 +7,19 @@ import {
   CarouselPrevious,
 } from "@blinkdisk/ui/carousel";
 import { SidebarOfflineAlert } from "@desktop/components/sidebar/offline-alert";
+import { SidebarReviewAlert } from "@desktop/components/sidebar/review-alert";
 import { SidebarStorageAlert } from "@desktop/components/sidebar/storage-alert";
 import { SidebarTrialAlert } from "@desktop/components/sidebar/trial-alert";
 import { SidebarUpdateAlert } from "@desktop/components/sidebar/update-alert";
 import { useSpace } from "@desktop/hooks/queries/use-space";
+import { useVault } from "@desktop/hooks/queries/use-vault";
 import { useUpdateDialog } from "@desktop/hooks/state/use-update-dialog";
+import { useAppStorage } from "@desktop/hooks/use-app-storage";
 import { useOffline } from "@desktop/hooks/use-offline";
 import AutoHeight from "embla-carousel-auto-height";
 import { type ReactNode, useEffect, useState } from "react";
+
+const REVIEW_ALERT_VAULT_AGE_MS = 12 * 60 * 60 * 1000;
 
 type SidebarAlertSlide = {
   key: string;
@@ -24,12 +29,21 @@ type SidebarAlertSlide = {
 export function SidebarAlerts() {
   const { isOffline } = useOffline();
   const { data: space } = useSpace();
+  const { data: vault } = useVault();
   const { status } = useUpdateDialog();
+  const [reviewDismissedAt] = useAppStorage("reviewDismissedAt");
   const [carouselApi, setCarouselApi] = useState<CarouselApi>();
   const [currentAlert, setCurrentAlert] = useState(0);
   const [scrollSnaps, setScrollSnaps] = useState<number[]>([]);
 
   const storagePercentage = space ? space.used / space.capacity : 0;
+
+  const showReviewAlert =
+    !reviewDismissedAt &&
+    !!vault?.createdAt &&
+    Date.now() - new Date(vault.createdAt).getTime() >
+      REVIEW_ALERT_VAULT_AGE_MS;
+
   const alerts: SidebarAlertSlide[] = [];
 
   if (status?.available) {
@@ -62,6 +76,13 @@ export function SidebarAlerts() {
     alerts.push({
       key: "storage",
       alert: <SidebarStorageAlert />,
+    });
+  }
+
+  if (showReviewAlert) {
+    alerts.push({
+      key: "review",
+      alert: <SidebarReviewAlert />,
     });
   }
 

--- a/apps/desktop/src/components/sidebar/review-alert.tsx
+++ b/apps/desktop/src/components/sidebar/review-alert.tsx
@@ -1,0 +1,47 @@
+import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
+import { Alert, AlertDescription, AlertTitle } from "@blinkdisk/ui/alert";
+import { Button } from "@blinkdisk/ui/button";
+import { SidebarMenuItem } from "@blinkdisk/ui/sidebar";
+import { useAppStorage } from "@desktop/hooks/use-app-storage";
+import { HeartIcon, XIcon } from "lucide-react";
+
+export function SidebarReviewAlert() {
+  const { t } = useAppTranslation("sidebar.reviewAlert");
+  const [, setReviewDismissedAt] = useAppStorage("reviewDismissedAt");
+
+  return (
+    <SidebarMenuItem>
+      <Alert variant="default" className="relative rounded-xl p-4">
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          aria-label={t("dismiss")}
+          className="text-muted-foreground absolute right-2 top-2"
+          onClick={() => setReviewDismissedAt(new Date().toISOString())}
+        >
+          <XIcon />
+        </Button>
+        <AlertTitle className="pr-8 text-lg font-semibold">
+          {t("title")}
+        </AlertTitle>
+        <AlertDescription className="mt-0.5 text-sm">
+          {t("description")}
+          <Button
+            className="mt-2.5 w-full"
+            size="sm"
+            render={
+              <a
+                href="https://alternativeto.net/software/blinkdisk/about/"
+                target="_blank"
+                rel="noreferrer"
+              />
+            }
+          >
+            <HeartIcon />
+            {t("button")}
+          </Button>
+        </AlertDescription>
+      </Alert>
+    </SidebarMenuItem>
+  );
+}

--- a/apps/electron/src/store.ts
+++ b/apps/electron/src/store.ts
@@ -9,6 +9,7 @@ export type GlobalStorageType = {
   authenticated: boolean;
   currentAccountId: string | null;
   dismissedUpdateVersion?: string | null;
+  reviewDismissedAt?: string | null;
   hasSkippedAuth: boolean;
   preferences: {
     theme: "system" | "dark" | "light";

--- a/locales/en/sidebar.json
+++ b/locales/en/sidebar.json
@@ -55,5 +55,11 @@
   "offlineAlert": {
     "title": "You're offline",
     "description": "Some features may not work while your device is offline."
+  },
+  "reviewAlert": {
+    "title": "Enjoying BlinkDisk?",
+    "description": "Help others find us by leaving a like on AlternativeTo.",
+    "button": "Like on AlternativeTo",
+    "dismiss": "Dismiss"
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a one-time “Like on AlternativeTo” alert in the desktop sidebar to encourage reviews after initial use. The alert shows once a vault is at least 12 hours old and can be dismissed.

- **New Features**
  - Added SidebarReviewAlert and integrated it into the sidebar alerts carousel.
  - Shows when `vault.createdAt` is older than 12h and `reviewDismissedAt` is not set; dismissal persists via global storage.
  - Includes CTA linking to AlternativeTo and a dismiss button; added English copy in `locales/en/sidebar.json`.

<sup>Written for commit 8ceda975bffc345186ba458b3ec2ff48f8367f29. Summary will update on new commits. <a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/225?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

