### PR TITLE
fix(cloud): allow listing blobs without prefix

### DIFF
--- a/apps/cloud/src/events/list.ts
+++ b/apps/cloud/src/events/list.ts
@@ -18,7 +18,7 @@ export async function listBlobs(
   const res = await durableObject.s3.send(
     new ListObjectsCommand({
       Bucket: durableObject.bucket,
-      Prefix: `${durableObject.id}/${payload.prefix}`,
+      Prefix: `${durableObject.id}/${payload.prefix || ""}`,
       MaxKeys: 1000,
       ...(payload.marker && { Marker: payload.marker }),
     }),

--- a/libs/schemas/src/cloud.ts
+++ b/libs/schemas/src/cloud.ts
@@ -7,6 +7,13 @@ const ZKey = z
     "Path must not include directory traversal patterns",
   );
 
+const ZListPrefix = z
+  .string()
+  .regex(
+    /^(?!.*(?:\.\.\/|\.\.\\)).*$/,
+    "Path must not include directory traversal patterns",
+  );
+
 export const ZCloudBase = z.object({
   requestId: z.string(),
 });
@@ -34,8 +41,8 @@ export const ZCloudDeleteBlob = ZCloudBase.extend(
 
 export const ZCloudListBlobs = ZCloudBase.extend(
   z.object({
-    prefix: ZKey,
-    marker: ZKey.optional(),
+    prefix: ZListPrefix.optional(),
+    marker: ZListPrefix.optional(),
   }).shape,
 );
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow listing blobs without a prefix in Cloud. The list API now accepts an omitted or empty prefix and correctly queries S3.

- **Bug Fixes**
  - Made `prefix` optional in `ZCloudListBlobs` using a traversal-safe `ZListPrefix`.
  - Updated S3 request to send `Prefix: ""` when no prefix is provided.
  - Switched `marker` to `ZListPrefix` for consistent validation.

<sup>Written for commit 958d6af73f80b1559902b24ef49970df9fe3a0e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

