### PR TITLE
fix(desktop): close auth dialog after deeplink login

### DIFF
--- a/apps/desktop/src/components/auth-listener.tsx
+++ b/apps/desktop/src/components/auth-listener.tsx
@@ -1,4 +1,5 @@
 import { LOCAL_ACCOUNT_ID } from "@blinkdisk/constants/account";
+import { useAuthDialog } from "@desktop/hooks/state/use-auth-dialog";
 import { useMoveVaultsDialog } from "@desktop/hooks/state/use-move-vaults-dialog";
 import { useAuth } from "@desktop/hooks/use-auth";
 import { getVaultCollection } from "@desktop/lib/db";
@@ -6,12 +7,15 @@ import { useNavigate } from "@tanstack/react-router";
 import { useCallback, useEffect } from "react";
 
 export function AuthListener() {
+  const { setIsOpen: setAuthDialogIsOpen } = useAuthDialog();
   const { openMoveVaultsDialog } = useMoveVaultsDialog();
   const { setAuthenticated, accountChanged } = useAuth();
   const navigate = useNavigate();
 
   const onAccountAdd = useCallback(
     async ({ accountId }: { accountId: string }) => {
+      setAuthDialogIsOpen(false);
+
       await setAuthenticated(true);
       await navigate({ to: "/{-$accountId}/loading" });
 
@@ -30,7 +34,13 @@ export function AuthListener() {
         });
       }
     },
-    [setAuthenticated, accountChanged, navigate, openMoveVaultsDialog],
+    [
+      setAuthDialogIsOpen,
+      setAuthenticated,
+      accountChanged,
+      navigate,
+      openMoveVaultsDialog,
+    ],
   );
 
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Close the auth dialog after deeplink login so it dismisses before navigation and doesn’t leave a stuck modal.

<sup>Written for commit b9df581808424c3dc960b3a5408793576ac7388c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

