### PR TITLE
fix(desktop): await vaults before opening create dialog

### DIFF
--- a/apps/desktop/src/hooks/use-auth.ts
+++ b/apps/desktop/src/hooks/use-auth.ts
@@ -52,8 +52,9 @@ export function useAuth() {
       const vaultCollection = getVaultCollection(accountId);
       await vaultCollection.isReady();
 
-      const hasActiveVaults = vaultCollection.find({ status: "ACTIVE" }).fetch()
-        .length;
+      const hasActiveVaults = vaultCollection
+        .find({ status: "ACTIVE" })
+        .fetch().length;
 
       if (!local && !hasActiveVaults) {
         openCreateVault({

--- a/apps/desktop/src/hooks/use-auth.ts
+++ b/apps/desktop/src/hooks/use-auth.ts
@@ -49,9 +49,11 @@ export function useAuth() {
         }),
       ]);
 
-      const hasActiveVaults = getVaultCollection(accountId)
-        .find({ status: "ACTIVE" })
-        .fetch().length;
+      const vaultCollection = getVaultCollection(accountId);
+      await vaultCollection.isReady();
+
+      const hasActiveVaults = vaultCollection.find({ status: "ACTIVE" }).fetch()
+        .length;
 
       if (!local && !hasActiveVaults) {
         openCreateVault({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure the desktop app waits for `vaultCollection.isReady()` in `useAuth` before checking ACTIVE vaults, so the Create Vault dialog only auto-opens when there are truly no active vaults. Also cleans up minor formatting.

<sup>Written for commit 13ec83473fa2a73774895aed04c1792f448b025c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

