### PR TITLE
feat(desktop): add stats to overview page

### DIFF
--- a/apps/desktop/src/components/vaults/overview.tsx
+++ b/apps/desktop/src/components/vaults/overview.tsx
@@ -55,6 +55,8 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
     return buildVaultStatHistory(backups);
   }, [backups]);
 
+  const isStatsLoading = !vault || !stats || !statHistory;
+
   return (
     <div
       className={cn(
@@ -67,19 +69,19 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
           title={t("stats.totalSize")}
           value={stats ? formatSize(stats.totalSize) : undefined}
           history={statHistory?.totalSize}
-          isLoading={!vault || !stats}
+          isLoading={isStatsLoading}
         />
         <VaultStatCard
           title={t("stats.files")}
           value={stats ? formatCompactInt(stats.fileCount) : undefined}
           history={statHistory?.fileCount}
-          isLoading={!vault || !stats}
+          isLoading={isStatsLoading}
         />
         <VaultStatCard
           title={t("stats.directories")}
           value={stats ? formatCompactInt(stats.directoryCount) : undefined}
           history={statHistory?.directoryCount}
-          isLoading={!vault || !stats}
+          isLoading={isStatsLoading}
         />
       </div>
       <div className="mt-8 flex items-center justify-between">

--- a/apps/desktop/src/components/vaults/overview.tsx
+++ b/apps/desktop/src/components/vaults/overview.tsx
@@ -1,30 +1,24 @@
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
-import { Card, CardContent, CardTitle } from "@blinkdisk/ui/card";
 import { Skeleton } from "@blinkdisk/ui/skeleton";
 import { cn } from "@blinkdisk/utils/class";
 import { Empty } from "@desktop/components/empty";
 import { FolderList } from "@desktop/components/folders/list";
 import { LocalButton } from "@desktop/components/vaults/local-button";
-import { VaultStatSparkline } from "@desktop/components/vaults/stat-sparkline";
+import { VaultStatCard } from "@desktop/components/vaults/stat-card";
 import { useStartBackup } from "@desktop/hooks/mutations/core/use-start-backup";
-import {
-  type CoreBackupItem,
-  useBackupList,
-} from "@desktop/hooks/queries/core/use-backup-list";
+import { useBackupList } from "@desktop/hooks/queries/core/use-backup-list";
 import {
   type CoreFolderItem,
-  useUnfilteredFolderList,
+  useFolderList,
 } from "@desktop/hooks/queries/core/use-folder-list";
 import type { VaultItem } from "@desktop/hooks/queries/use-vault";
 import { useCreateFolderDialog } from "@desktop/hooks/state/use-create-folder-dialog";
 import { formatCompactInt, formatSize } from "@desktop/lib/number";
 import {
-  ArrowDownRightIcon,
-  ArrowUpRightIcon,
-  CloudUploadIcon,
-  FolderPlusIcon,
-  PlusIcon,
-} from "lucide-react";
+  buildVaultStatHistory,
+  buildVaultStats,
+} from "@desktop/lib/vault-stats";
+import { CloudUploadIcon, FolderPlusIcon, PlusIcon } from "lucide-react";
 import { useMemo } from "react";
 
 type VaultOverviewProps = {
@@ -37,7 +31,7 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
 
   const { openCreateFolder } = useCreateFolderDialog();
   const { mutate: startBackup, isPending: isStartingBackup } = useStartBackup();
-  const { data: allFolders } = useUnfilteredFolderList();
+  const { data: allFolders } = useFolderList({ unfiltered: true });
   const { data: backups } = useBackupList({ filters: "none" });
 
   const isAnyBackupRunning = useMemo(
@@ -52,23 +46,7 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
   const stats = useMemo(() => {
     if (!allFolders) return null;
 
-    return {
-      totalSize: allFolders.reduce(
-        (sum, folder) => sum + (folder.lastSnapshot?.stats.totalSize || 0),
-        0,
-      ),
-      fileCount: allFolders.reduce(
-        (sum, folder) =>
-          sum +
-          (folder.lastSnapshot?.stats.nonCachedFiles || 0) +
-          (folder.lastSnapshot?.stats.cachedFiles || 0),
-        0,
-      ),
-      directoryCount: allFolders.reduce(
-        (sum, folder) => sum + (folder.lastSnapshot?.stats.dirCount || 0),
-        0,
-      ),
-    };
+    return buildVaultStats(allFolders);
   }, [allFolders]);
 
   const statHistory = useMemo(() => {
@@ -87,21 +65,18 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
       <div className="grid grid-cols-3 gap-6">
         <VaultStatCard
           title={t("stats.totalSize")}
-          description={t("stats.totalSizeDescription")}
           value={stats ? formatSize(stats.totalSize) : undefined}
           history={statHistory?.totalSize}
           isLoading={!vault || !stats}
         />
         <VaultStatCard
           title={t("stats.files")}
-          description={t("stats.filesDescription")}
           value={stats ? formatCompactInt(stats.fileCount) : undefined}
           history={statHistory?.fileCount}
           isLoading={!vault || !stats}
         />
         <VaultStatCard
           title={t("stats.directories")}
-          description={t("stats.directoriesDescription")}
           value={stats ? formatCompactInt(stats.directoryCount) : undefined}
           history={statHistory?.directoryCount}
           isLoading={!vault || !stats}
@@ -167,124 +142,5 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
         <FolderList folders={folders} />
       )}
     </div>
-  );
-}
-
-type VaultStatCardProps = {
-  title: string;
-  description: string;
-  value?: string;
-  history?: number[];
-  isLoading: boolean;
-};
-
-function VaultStatCard({
-  title,
-  value,
-  history,
-  isLoading,
-}: VaultStatCardProps) {
-  const trend = getHistoryTrend(history);
-  const TrendIcon =
-    trend.direction === "down" ? ArrowDownRightIcon : ArrowUpRightIcon;
-
-  return (
-    <Card className="overflow-hidden py-0">
-      <CardContent className="flex h-full flex-col p-5">
-        <div className="flex items-start justify-between gap-4">
-          <CardTitle className="text-muted-foreground min-w-0 text-sm font-medium">
-            {!isLoading ? title : <Skeleton width={90} />}
-          </CardTitle>
-          {!isLoading ? (
-            <div className="text-foreground flex shrink-0 items-center gap-1 text-xs font-semibold">
-              <TrendIcon className="size-4" />
-              {formatTrendPercent(trend.percent)}
-            </div>
-          ) : null}
-        </div>
-        <div className="mt-auto flex items-end justify-between gap-4 pt-5">
-          <p className="shrink-0 whitespace-nowrap text-4xl font-semibold tracking-normal">
-            {!isLoading ? value : <Skeleton width={120} />}
-          </p>
-          {!isLoading ? (
-            <VaultStatSparkline
-              className="pointer-events-none h-10 min-w-0 max-w-48 flex-1 text-zinc-400 dark:text-zinc-500"
-              values={history ?? []}
-            />
-          ) : null}
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function getHistoryTrend(history?: number[]) {
-  const first = history?.find((value) => value > 0) ?? history?.[0] ?? 0;
-  const last = history?.[history.length - 1] ?? 0;
-  const percent =
-    first === 0 ? (last > 0 ? 100 : 0) : ((last - first) / first) * 100;
-
-  return {
-    direction: percent < 0 ? "down" : "up",
-    percent: Math.abs(percent),
-  };
-}
-
-function formatTrendPercent(percent: number) {
-  return `${percent.toLocaleString(undefined, {
-    maximumFractionDigits: 1,
-    minimumFractionDigits: 1,
-  })}%`;
-}
-
-function buildVaultStatHistory(backups: CoreBackupItem[]) {
-  const days = Array.from({ length: 30 }, (_, index) => {
-    const date = new Date();
-    date.setHours(0, 0, 0, 0);
-    date.setDate(date.getDate() - (29 - index));
-    return date;
-  });
-  const sortedBackups = [...backups]
-    .filter((backup) => backup.incomplete === undefined)
-    .sort(
-      (a, b) =>
-        new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
-    );
-  const latestByRoot = new Map<string, CoreBackupItem>();
-  let backupIndex = 0;
-
-  return days.reduce(
-    (history, day) => {
-      const nextDay = new Date(day);
-      nextDay.setDate(day.getDate() + 1);
-
-      while (backupIndex < sortedBackups.length) {
-        const backup = sortedBackups[backupIndex];
-        if (!backup || new Date(backup.startTime) >= nextDay) break;
-
-        latestByRoot.set(backup.rootID, backup);
-        backupIndex += 1;
-      }
-
-      const totals = Array.from(latestByRoot.values()).reduce(
-        (sum, backup) => ({
-          totalSize: sum.totalSize + backup.summary.size,
-          fileCount: sum.fileCount + backup.summary.files,
-          directoryCount: sum.directoryCount + backup.summary.dirs,
-        }),
-        { totalSize: 0, fileCount: 0, directoryCount: 0 },
-      );
-
-      history.totalSize.push(totals.totalSize);
-      history.fileCount.push(totals.fileCount);
-      history.directoryCount.push(totals.directoryCount);
-
-      return history;
-    },
-    {
-      totalSize: [] as number[],
-      fileCount: [] as number[],
-      directoryCount: [] as number[],
-    },
   );
 }

--- a/apps/desktop/src/components/vaults/overview.tsx
+++ b/apps/desktop/src/components/vaults/overview.tsx
@@ -48,8 +48,6 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
   const stats = useMemo(() => {
     if (!allFolders) return null;
 
-    console.log(allFolders);
-
     return {
       totalSize: allFolders.reduce(
         (sum, folder) => sum + (folder.lastSnapshot?.stats.totalSize || 0),
@@ -80,7 +78,6 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
           description={t("stats.totalSizeDescription")}
           value={stats ? formatSize(stats.totalSize) : undefined}
           isLoading={!vault || !stats}
-          accent="cyan"
         />
         <VaultStatCard
           icon={<FilesIcon />}
@@ -88,7 +85,6 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
           description={t("stats.filesDescription")}
           value={stats ? formatInt(stats.fileCount) : undefined}
           isLoading={!vault || !stats}
-          accent="emerald"
         />
         <VaultStatCard
           icon={<MonitorIcon />}
@@ -96,7 +92,6 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
           description={t("stats.devicesDescription")}
           value={stats ? formatInt(stats.deviceCount) : undefined}
           isLoading={!vault || !stats}
-          accent="amber"
         />
       </div>
       <div className="mt-8 flex items-center justify-between">

--- a/apps/desktop/src/components/vaults/overview.tsx
+++ b/apps/desktop/src/components/vaults/overview.tsx
@@ -13,15 +13,7 @@ import {
 import type { VaultItem } from "@desktop/hooks/queries/use-vault";
 import { useCreateFolderDialog } from "@desktop/hooks/state/use-create-folder-dialog";
 import { formatInt, formatSize } from "@desktop/lib/number";
-import {
-  CloudUploadIcon,
-  DatabaseIcon,
-  FilesIcon,
-  FolderPlusIcon,
-  MonitorIcon,
-  PlusIcon,
-} from "lucide-react";
-import type { ReactNode } from "react";
+import { CloudUploadIcon, FolderPlusIcon, PlusIcon } from "lucide-react";
 import { useMemo } from "react";
 
 type VaultOverviewProps = {
@@ -60,7 +52,10 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
           (folder.lastSnapshot?.stats.cachedFiles || 0),
         0,
       ),
-      deviceCount: new Set(allFolders.map((folder) => folder.source.host)).size,
+      directoryCount: allFolders.reduce(
+        (sum, folder) => sum + (folder.lastSnapshot?.stats.dirCount || 0),
+        0,
+      ),
     };
   }, [allFolders]);
 
@@ -73,24 +68,21 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
     >
       <div className="grid grid-cols-3 gap-6">
         <VaultStatCard
-          icon={<DatabaseIcon />}
           title={t("stats.totalSize")}
           description={t("stats.totalSizeDescription")}
           value={stats ? formatSize(stats.totalSize) : undefined}
           isLoading={!vault || !stats}
         />
         <VaultStatCard
-          icon={<FilesIcon />}
           title={t("stats.files")}
           description={t("stats.filesDescription")}
           value={stats ? formatInt(stats.fileCount) : undefined}
           isLoading={!vault || !stats}
         />
         <VaultStatCard
-          icon={<MonitorIcon />}
-          title={t("stats.devices")}
-          description={t("stats.devicesDescription")}
-          value={stats ? formatInt(stats.deviceCount) : undefined}
+          title={t("stats.directories")}
+          description={t("stats.directoriesDescription")}
+          value={stats ? formatInt(stats.directoryCount) : undefined}
           isLoading={!vault || !stats}
         />
       </div>
@@ -158,57 +150,28 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
 }
 
 type VaultStatCardProps = {
-  icon: ReactNode;
   title: string;
   description: string;
   value?: string;
   isLoading: boolean;
-  accent: "cyan" | "emerald" | "amber";
 };
 
 function VaultStatCard({
-  icon,
   title,
   description,
   value,
   isLoading,
-  accent,
 }: VaultStatCardProps) {
   return (
-    <Card
-      className={cn(
-        "relative min-h-32 overflow-hidden py-0",
-        "before:absolute before:inset-x-0 before:top-0 before:h-1",
-        accent === "cyan" && "before:bg-cyan-500/80 dark:before:bg-cyan-400/80",
-        accent === "emerald" &&
-          "before:bg-emerald-500/80 dark:before:bg-emerald-400/80",
-        accent === "amber" &&
-          "before:bg-amber-500/80 dark:before:bg-amber-400/80",
-      )}
-    >
+    <Card className="min-h-32 overflow-hidden py-0">
       <CardContent className="relative flex h-full flex-col justify-between p-5">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex min-w-0 flex-col">
-            <CardTitle className="text-muted-foreground text-sm font-medium">
-              {!isLoading ? title : <Skeleton width={90} />}
-            </CardTitle>
-            <p className="mt-2 truncate text-4xl font-semibold tracking-normal">
-              {!isLoading ? value : <Skeleton width={120} />}
-            </p>
-          </div>
-          <div
-            className={cn(
-              "flex size-11 shrink-0 items-center justify-center rounded-lg border [&_svg]:size-5",
-              accent === "cyan" &&
-                "border-cyan-500/20 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
-              accent === "emerald" &&
-                "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
-              accent === "amber" &&
-                "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
-            )}
-          >
-            {icon}
-          </div>
+        <div className="flex min-w-0 flex-col">
+          <CardTitle className="text-muted-foreground text-sm font-medium">
+            {!isLoading ? title : <Skeleton width={90} />}
+          </CardTitle>
+          <p className="mt-2 truncate text-4xl font-semibold tracking-normal">
+            {!isLoading ? value : <Skeleton width={120} />}
+          </p>
         </div>
         <p className="text-muted-foreground mt-4 truncate text-xs">
           {!isLoading ? description : <Skeleton width={150} />}

--- a/apps/desktop/src/components/vaults/overview.tsx
+++ b/apps/desktop/src/components/vaults/overview.tsx
@@ -18,7 +18,13 @@ import {
 import type { VaultItem } from "@desktop/hooks/queries/use-vault";
 import { useCreateFolderDialog } from "@desktop/hooks/state/use-create-folder-dialog";
 import { formatInt, formatSize } from "@desktop/lib/number";
-import { CloudUploadIcon, FolderPlusIcon, PlusIcon } from "lucide-react";
+import {
+  ArrowDownRightIcon,
+  ArrowUpRightIcon,
+  CloudUploadIcon,
+  FolderPlusIcon,
+  PlusIcon,
+} from "lucide-react";
 import { useMemo } from "react";
 
 type VaultOverviewProps = {
@@ -174,29 +180,61 @@ type VaultStatCardProps = {
 
 function VaultStatCard({
   title,
-  description,
   value,
   history,
   isLoading,
 }: VaultStatCardProps) {
+  const trend = getHistoryTrend(history);
+  const TrendIcon =
+    trend.direction === "down" ? ArrowDownRightIcon : ArrowUpRightIcon;
+
   return (
-    <Card className="min-h-32 overflow-hidden py-0">
-      <CardContent className="relative flex h-full flex-col justify-between p-5">
-        {!isLoading ? <VaultStatSparkline values={history ?? []} /> : null}
-        <div className="flex min-w-0 flex-col">
-          <CardTitle className="text-muted-foreground text-sm font-medium">
+    <Card className="overflow-hidden py-0">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between gap-4">
+          <CardTitle className="text-muted-foreground min-w-0 text-sm font-medium">
             {!isLoading ? title : <Skeleton width={90} />}
           </CardTitle>
-          <p className="mt-2 truncate text-4xl font-semibold tracking-normal">
+          {!isLoading ? (
+            <div className="text-foreground flex shrink-0 items-center gap-1 text-xs font-semibold">
+              <TrendIcon className="size-4" />
+              {formatTrendPercent(trend.percent)}
+            </div>
+          ) : null}
+        </div>
+        <div className="mt-5 flex items-end justify-between gap-4">
+          <p className="shrink-0 whitespace-nowrap text-4xl font-semibold tracking-normal">
             {!isLoading ? value : <Skeleton width={120} />}
           </p>
+          {!isLoading ? (
+            <VaultStatSparkline
+              className="text-foreground pointer-events-none h-10 min-w-0 max-w-48 flex-1"
+              values={history ?? []}
+            />
+          ) : null}
         </div>
-        <p className="text-muted-foreground mt-4 truncate text-xs">
-          {!isLoading ? description : <Skeleton width={150} />}
-        </p>
       </CardContent>
     </Card>
   );
+}
+
+function getHistoryTrend(history?: number[]) {
+  const first = history?.find((value) => value > 0) ?? history?.[0] ?? 0;
+  const last = history?.[history.length - 1] ?? 0;
+  const percent =
+    first === 0 ? (last > 0 ? 100 : 0) : ((last - first) / first) * 100;
+
+  return {
+    direction: percent < 0 ? "down" : "up",
+    percent: Math.abs(percent),
+  };
+}
+
+function formatTrendPercent(percent: number) {
+  return `${percent.toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 1,
+  })}%`;
 }
 
 function buildVaultStatHistory(backups: CoreBackupItem[]) {

--- a/apps/desktop/src/components/vaults/overview.tsx
+++ b/apps/desktop/src/components/vaults/overview.tsx
@@ -17,7 +17,7 @@ import {
 } from "@desktop/hooks/queries/core/use-folder-list";
 import type { VaultItem } from "@desktop/hooks/queries/use-vault";
 import { useCreateFolderDialog } from "@desktop/hooks/state/use-create-folder-dialog";
-import { formatInt, formatSize } from "@desktop/lib/number";
+import { formatCompactInt, formatSize } from "@desktop/lib/number";
 import {
   ArrowDownRightIcon,
   ArrowUpRightIcon,
@@ -95,14 +95,14 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
         <VaultStatCard
           title={t("stats.files")}
           description={t("stats.filesDescription")}
-          value={stats ? formatInt(stats.fileCount) : undefined}
+          value={stats ? formatCompactInt(stats.fileCount) : undefined}
           history={statHistory?.fileCount}
           isLoading={!vault || !stats}
         />
         <VaultStatCard
           title={t("stats.directories")}
           description={t("stats.directoriesDescription")}
-          value={stats ? formatInt(stats.directoryCount) : undefined}
+          value={stats ? formatCompactInt(stats.directoryCount) : undefined}
           history={statHistory?.directoryCount}
           isLoading={!vault || !stats}
         />

--- a/apps/desktop/src/components/vaults/overview.tsx
+++ b/apps/desktop/src/components/vaults/overview.tsx
@@ -1,16 +1,27 @@
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
+import { Card, CardContent, CardTitle } from "@blinkdisk/ui/card";
 import { Skeleton } from "@blinkdisk/ui/skeleton";
 import { cn } from "@blinkdisk/utils/class";
-import { HealthCard } from "@desktop/components/accounts/health-card";
-import { StorageCard } from "@desktop/components/accounts/storage-card";
 import { Empty } from "@desktop/components/empty";
 import { FolderList } from "@desktop/components/folders/list";
 import { LocalButton } from "@desktop/components/vaults/local-button";
 import { useStartBackup } from "@desktop/hooks/mutations/core/use-start-backup";
-import type { CoreFolderItem } from "@desktop/hooks/queries/core/use-folder-list";
+import {
+  type CoreFolderItem,
+  useUnfilteredFolderList,
+} from "@desktop/hooks/queries/core/use-folder-list";
 import type { VaultItem } from "@desktop/hooks/queries/use-vault";
 import { useCreateFolderDialog } from "@desktop/hooks/state/use-create-folder-dialog";
-import { CloudUploadIcon, FolderPlusIcon, PlusIcon } from "lucide-react";
+import { formatInt, formatSize } from "@desktop/lib/number";
+import {
+  CloudUploadIcon,
+  DatabaseIcon,
+  FilesIcon,
+  FolderPlusIcon,
+  MonitorIcon,
+  PlusIcon,
+} from "lucide-react";
+import type { ReactNode } from "react";
 import { useMemo } from "react";
 
 type VaultOverviewProps = {
@@ -23,6 +34,7 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
 
   const { openCreateFolder } = useCreateFolderDialog();
   const { mutate: startBackup, isPending: isStartingBackup } = useStartBackup();
+  const { data: allFolders } = useUnfilteredFolderList();
 
   const isAnyBackupRunning = useMemo(
     () =>
@@ -33,6 +45,27 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
     [folders],
   );
 
+  const stats = useMemo(() => {
+    if (!allFolders) return null;
+
+    console.log(allFolders);
+
+    return {
+      totalSize: allFolders.reduce(
+        (sum, folder) => sum + (folder.lastSnapshot?.stats.totalSize || 0),
+        0,
+      ),
+      fileCount: allFolders.reduce(
+        (sum, folder) =>
+          sum +
+          (folder.lastSnapshot?.stats.nonCachedFiles || 0) +
+          (folder.lastSnapshot?.stats.cachedFiles || 0),
+        0,
+      ),
+      deviceCount: new Set(allFolders.map((folder) => folder.source.host)).size,
+    };
+  }, [allFolders]);
+
   return (
     <div
       className={cn(
@@ -40,11 +73,31 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
         folders !== undefined ? "overflow-y-auto" : "overflow-hidden",
       )}
     >
-      <div className="flex flex-row gap-6">
-        <HealthCard isLoading={!vault} />
-        {!vault || (vault && vault.provider === "CLOUDBLINK") ? (
-          <StorageCard isLoading={!vault} />
-        ) : null}
+      <div className="grid grid-cols-3 gap-6">
+        <VaultStatCard
+          icon={<DatabaseIcon />}
+          title={t("stats.totalSize")}
+          description={t("stats.totalSizeDescription")}
+          value={stats ? formatSize(stats.totalSize) : undefined}
+          isLoading={!vault || !stats}
+          accent="cyan"
+        />
+        <VaultStatCard
+          icon={<FilesIcon />}
+          title={t("stats.files")}
+          description={t("stats.filesDescription")}
+          value={stats ? formatInt(stats.fileCount) : undefined}
+          isLoading={!vault || !stats}
+          accent="emerald"
+        />
+        <VaultStatCard
+          icon={<MonitorIcon />}
+          title={t("stats.devices")}
+          description={t("stats.devicesDescription")}
+          value={stats ? formatInt(stats.deviceCount) : undefined}
+          isLoading={!vault || !stats}
+          accent="amber"
+        />
       </div>
       <div className="mt-8 flex items-center justify-between">
         <div className="flex flex-col">
@@ -106,5 +159,66 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
         <FolderList folders={folders} />
       )}
     </div>
+  );
+}
+
+type VaultStatCardProps = {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  value?: string;
+  isLoading: boolean;
+  accent: "cyan" | "emerald" | "amber";
+};
+
+function VaultStatCard({
+  icon,
+  title,
+  description,
+  value,
+  isLoading,
+  accent,
+}: VaultStatCardProps) {
+  return (
+    <Card
+      className={cn(
+        "relative min-h-32 overflow-hidden py-0",
+        "before:absolute before:inset-x-0 before:top-0 before:h-1",
+        accent === "cyan" && "before:bg-cyan-500/80 dark:before:bg-cyan-400/80",
+        accent === "emerald" &&
+          "before:bg-emerald-500/80 dark:before:bg-emerald-400/80",
+        accent === "amber" &&
+          "before:bg-amber-500/80 dark:before:bg-amber-400/80",
+      )}
+    >
+      <CardContent className="relative flex h-full flex-col justify-between p-5">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex min-w-0 flex-col">
+            <CardTitle className="text-muted-foreground text-sm font-medium">
+              {!isLoading ? title : <Skeleton width={90} />}
+            </CardTitle>
+            <p className="mt-2 truncate text-4xl font-semibold tracking-normal">
+              {!isLoading ? value : <Skeleton width={120} />}
+            </p>
+          </div>
+          <div
+            className={cn(
+              "flex size-11 shrink-0 items-center justify-center rounded-lg border [&_svg]:size-5",
+              accent === "cyan" &&
+                "border-cyan-500/20 bg-cyan-500/10 text-cyan-700 dark:text-cyan-300",
+              accent === "emerald" &&
+                "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300",
+              accent === "amber" &&
+                "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+            )}
+          >
+            {icon}
+          </div>
+        </div>
+        <p className="text-muted-foreground mt-4 truncate text-xs">
+          {!isLoading ? description : <Skeleton width={150} />}
+        </p>
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/desktop/src/components/vaults/overview.tsx
+++ b/apps/desktop/src/components/vaults/overview.tsx
@@ -5,7 +5,12 @@ import { cn } from "@blinkdisk/utils/class";
 import { Empty } from "@desktop/components/empty";
 import { FolderList } from "@desktop/components/folders/list";
 import { LocalButton } from "@desktop/components/vaults/local-button";
+import { VaultStatSparkline } from "@desktop/components/vaults/stat-sparkline";
 import { useStartBackup } from "@desktop/hooks/mutations/core/use-start-backup";
+import {
+  type CoreBackupItem,
+  useBackupList,
+} from "@desktop/hooks/queries/core/use-backup-list";
 import {
   type CoreFolderItem,
   useUnfilteredFolderList,
@@ -27,6 +32,7 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
   const { openCreateFolder } = useCreateFolderDialog();
   const { mutate: startBackup, isPending: isStartingBackup } = useStartBackup();
   const { data: allFolders } = useUnfilteredFolderList();
+  const { data: backups } = useBackupList({ filters: "none" });
 
   const isAnyBackupRunning = useMemo(
     () =>
@@ -59,6 +65,12 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
     };
   }, [allFolders]);
 
+  const statHistory = useMemo(() => {
+    if (!backups) return null;
+
+    return buildVaultStatHistory(backups);
+  }, [backups]);
+
   return (
     <div
       className={cn(
@@ -71,18 +83,21 @@ export function VaultOverview({ vault, folders }: VaultOverviewProps) {
           title={t("stats.totalSize")}
           description={t("stats.totalSizeDescription")}
           value={stats ? formatSize(stats.totalSize) : undefined}
+          history={statHistory?.totalSize}
           isLoading={!vault || !stats}
         />
         <VaultStatCard
           title={t("stats.files")}
           description={t("stats.filesDescription")}
           value={stats ? formatInt(stats.fileCount) : undefined}
+          history={statHistory?.fileCount}
           isLoading={!vault || !stats}
         />
         <VaultStatCard
           title={t("stats.directories")}
           description={t("stats.directoriesDescription")}
           value={stats ? formatInt(stats.directoryCount) : undefined}
+          history={statHistory?.directoryCount}
           isLoading={!vault || !stats}
         />
       </div>
@@ -153,6 +168,7 @@ type VaultStatCardProps = {
   title: string;
   description: string;
   value?: string;
+  history?: number[];
   isLoading: boolean;
 };
 
@@ -160,11 +176,13 @@ function VaultStatCard({
   title,
   description,
   value,
+  history,
   isLoading,
 }: VaultStatCardProps) {
   return (
     <Card className="min-h-32 overflow-hidden py-0">
       <CardContent className="relative flex h-full flex-col justify-between p-5">
+        {!isLoading ? <VaultStatSparkline values={history ?? []} /> : null}
         <div className="flex min-w-0 flex-col">
           <CardTitle className="text-muted-foreground text-sm font-medium">
             {!isLoading ? title : <Skeleton width={90} />}
@@ -178,5 +196,57 @@ function VaultStatCard({
         </p>
       </CardContent>
     </Card>
+  );
+}
+
+function buildVaultStatHistory(backups: CoreBackupItem[]) {
+  const days = Array.from({ length: 30 }, (_, index) => {
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() - (29 - index));
+    return date;
+  });
+  const sortedBackups = [...backups]
+    .filter((backup) => backup.incomplete === undefined)
+    .sort(
+      (a, b) =>
+        new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+    );
+  const latestByRoot = new Map<string, CoreBackupItem>();
+  let backupIndex = 0;
+
+  return days.reduce(
+    (history, day) => {
+      const nextDay = new Date(day);
+      nextDay.setDate(day.getDate() + 1);
+
+      while (backupIndex < sortedBackups.length) {
+        const backup = sortedBackups[backupIndex];
+        if (!backup || new Date(backup.startTime) >= nextDay) break;
+
+        latestByRoot.set(backup.rootID, backup);
+        backupIndex += 1;
+      }
+
+      const totals = Array.from(latestByRoot.values()).reduce(
+        (sum, backup) => ({
+          totalSize: sum.totalSize + backup.summary.size,
+          fileCount: sum.fileCount + backup.summary.files,
+          directoryCount: sum.directoryCount + backup.summary.dirs,
+        }),
+        { totalSize: 0, fileCount: 0, directoryCount: 0 },
+      );
+
+      history.totalSize.push(totals.totalSize);
+      history.fileCount.push(totals.fileCount);
+      history.directoryCount.push(totals.directoryCount);
+
+      return history;
+    },
+    {
+      totalSize: [] as number[],
+      fileCount: [] as number[],
+      directoryCount: [] as number[],
+    },
   );
 }

--- a/apps/desktop/src/components/vaults/overview.tsx
+++ b/apps/desktop/src/components/vaults/overview.tsx
@@ -190,7 +190,7 @@ function VaultStatCard({
 
   return (
     <Card className="overflow-hidden py-0">
-      <CardContent className="p-5">
+      <CardContent className="flex h-full flex-col p-5">
         <div className="flex items-start justify-between gap-4">
           <CardTitle className="text-muted-foreground min-w-0 text-sm font-medium">
             {!isLoading ? title : <Skeleton width={90} />}
@@ -202,13 +202,13 @@ function VaultStatCard({
             </div>
           ) : null}
         </div>
-        <div className="mt-5 flex items-end justify-between gap-4">
+        <div className="mt-auto flex items-end justify-between gap-4 pt-5">
           <p className="shrink-0 whitespace-nowrap text-4xl font-semibold tracking-normal">
             {!isLoading ? value : <Skeleton width={120} />}
           </p>
           {!isLoading ? (
             <VaultStatSparkline
-              className="text-foreground pointer-events-none h-10 min-w-0 max-w-48 flex-1"
+              className="pointer-events-none h-10 min-w-0 max-w-48 flex-1 text-zinc-400 dark:text-zinc-500"
               values={history ?? []}
             />
           ) : null}

--- a/apps/desktop/src/components/vaults/stat-card.test.ts
+++ b/apps/desktop/src/components/vaults/stat-card.test.ts
@@ -1,0 +1,28 @@
+import { getHistoryTrend } from "@desktop/components/vaults/stat-card";
+
+describe("getHistoryTrend", () => {
+  it.each([
+    { history: [10, 10, 10], name: "steady history" },
+    { history: [0, 0, 0], name: "all-zero history" },
+    { history: undefined, name: "missing history" },
+  ])("returns flat for $name", ({ history }) => {
+    expect(getHistoryTrend(history)).toEqual({
+      direction: "flat",
+      percent: 0,
+    });
+  });
+
+  it("returns up for positive change", () => {
+    expect(getHistoryTrend([10, 15])).toEqual({
+      direction: "up",
+      percent: 50,
+    });
+  });
+
+  it("returns down for negative change", () => {
+    expect(getHistoryTrend([10, 5])).toEqual({
+      direction: "down",
+      percent: 50,
+    });
+  });
+});

--- a/apps/desktop/src/components/vaults/stat-card.tsx
+++ b/apps/desktop/src/components/vaults/stat-card.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardTitle } from "@blinkdisk/ui/card";
 import { Skeleton } from "@blinkdisk/ui/skeleton";
 import { Sparkline } from "@blinkdisk/ui/sparkline";
-import { ArrowDownRightIcon, ArrowUpRightIcon } from "lucide-react";
+import { ArrowDownRightIcon, ArrowUpRightIcon, MinusIcon } from "lucide-react";
 
 type VaultStatCardProps = {
   title: string;
@@ -18,7 +18,11 @@ export function VaultStatCard({
 }: VaultStatCardProps) {
   const trend = getHistoryTrend(history);
   const TrendIcon =
-    trend.direction === "down" ? ArrowDownRightIcon : ArrowUpRightIcon;
+    trend.direction === "down"
+      ? ArrowDownRightIcon
+      : trend.direction === "up"
+        ? ArrowUpRightIcon
+        : MinusIcon;
 
   return (
     <Card className="overflow-hidden py-0">
@@ -50,14 +54,14 @@ export function VaultStatCard({
   );
 }
 
-function getHistoryTrend(history?: number[]) {
+export function getHistoryTrend(history?: number[]) {
   const first = history?.find((value) => value > 0) ?? history?.[0] ?? 0;
   const last = history?.[history.length - 1] ?? 0;
   const percent =
     first === 0 ? (last > 0 ? 100 : 0) : ((last - first) / first) * 100;
 
   return {
-    direction: percent < 0 ? "down" : "up",
+    direction: percent < 0 ? "down" : percent > 0 ? "up" : "flat",
     percent: Math.abs(percent),
   };
 }

--- a/apps/desktop/src/components/vaults/stat-card.tsx
+++ b/apps/desktop/src/components/vaults/stat-card.tsx
@@ -1,0 +1,70 @@
+import { Card, CardContent, CardTitle } from "@blinkdisk/ui/card";
+import { Skeleton } from "@blinkdisk/ui/skeleton";
+import { Sparkline } from "@blinkdisk/ui/sparkline";
+import { ArrowDownRightIcon, ArrowUpRightIcon } from "lucide-react";
+
+type VaultStatCardProps = {
+  title: string;
+  value?: string;
+  history?: number[];
+  isLoading: boolean;
+};
+
+export function VaultStatCard({
+  title,
+  value,
+  history,
+  isLoading,
+}: VaultStatCardProps) {
+  const trend = getHistoryTrend(history);
+  const TrendIcon =
+    trend.direction === "down" ? ArrowDownRightIcon : ArrowUpRightIcon;
+
+  return (
+    <Card className="overflow-hidden py-0">
+      <CardContent className="flex h-full flex-col p-5">
+        <div className="flex items-start justify-between gap-4">
+          <CardTitle className="text-muted-foreground min-w-0 text-sm font-medium">
+            {!isLoading ? title : <Skeleton width={90} />}
+          </CardTitle>
+          {!isLoading ? (
+            <div className="text-foreground flex shrink-0 items-center gap-1 text-xs font-semibold">
+              <TrendIcon className="size-4" />
+              {formatTrendPercent(trend.percent)}
+            </div>
+          ) : null}
+        </div>
+        <div className="mt-auto flex items-end justify-between gap-4 pt-5">
+          <p className="shrink-0 whitespace-nowrap text-4xl font-semibold tracking-normal">
+            {!isLoading ? value : <Skeleton width={120} />}
+          </p>
+          {!isLoading ? (
+            <Sparkline
+              className="pointer-events-none h-10 min-w-0 max-w-48 flex-1 text-zinc-400 dark:text-zinc-500"
+              values={history ?? []}
+            />
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function getHistoryTrend(history?: number[]) {
+  const first = history?.find((value) => value > 0) ?? history?.[0] ?? 0;
+  const last = history?.[history.length - 1] ?? 0;
+  const percent =
+    first === 0 ? (last > 0 ? 100 : 0) : ((last - first) / first) * 100;
+
+  return {
+    direction: percent < 0 ? "down" : "up",
+    percent: Math.abs(percent),
+  };
+}
+
+function formatTrendPercent(percent: number) {
+  return `${percent.toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 1,
+  })}%`;
+}

--- a/apps/desktop/src/components/vaults/stat-sparkline.tsx
+++ b/apps/desktop/src/components/vaults/stat-sparkline.tsx
@@ -1,10 +1,14 @@
 import { useId } from "react";
 
 type VaultStatSparklineProps = {
+  className?: string;
   values: number[];
 };
 
-export function VaultStatSparkline({ values }: VaultStatSparklineProps) {
+export function VaultStatSparkline({
+  className,
+  values,
+}: VaultStatSparklineProps) {
   const gradientId = useId().replace(/:/g, "");
   const width = 130;
   const height = 52;
@@ -45,7 +49,7 @@ export function VaultStatSparkline({ values }: VaultStatSparklineProps) {
   return (
     <svg
       aria-hidden="true"
-      className="text-primary pointer-events-none absolute top-5 right-5 h-13 w-32"
+      className={className}
       preserveAspectRatio="none"
       viewBox={`0 0 ${width} ${height}`}
     >
@@ -62,9 +66,20 @@ export function VaultStatSparkline({ values }: VaultStatSparklineProps) {
         stroke="currentColor"
         strokeLinecap="round"
         strokeLinejoin="round"
-        strokeOpacity="0.62"
+        strokeOpacity="0.8"
         strokeWidth="2.25"
         vectorEffect="non-scaling-stroke"
+      />
+      <line
+        opacity="0.75"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="6"
+        vectorEffect="non-scaling-stroke"
+        x1={lastPoint.x}
+        x2={lastPoint.x}
+        y1={lastPoint.y}
+        y2={lastPoint.y}
       />
     </svg>
   );

--- a/apps/desktop/src/components/vaults/stat-sparkline.tsx
+++ b/apps/desktop/src/components/vaults/stat-sparkline.tsx
@@ -1,0 +1,71 @@
+import { useId } from "react";
+
+type VaultStatSparklineProps = {
+  values: number[];
+};
+
+export function VaultStatSparkline({ values }: VaultStatSparklineProps) {
+  const gradientId = useId().replace(/:/g, "");
+  const width = 130;
+  const height = 52;
+  const padding = 3;
+  const max = Math.max(...values, 0);
+  const min = Math.min(...values, 0);
+  const range = max - min || 1;
+
+  const points = values.map((value, index) => {
+    const x =
+      values.length <= 1
+        ? width
+        : (index / (values.length - 1)) * (width - padding * 2) + padding;
+    const y =
+      height - padding - ((value - min) / range) * (height - padding * 2);
+
+    return { x, y };
+  });
+
+  if (points.length < 2) return null;
+
+  const linePath = points.reduce((path, point, index) => {
+    if (index === 0) return `M ${point.x} ${point.y}`;
+
+    const previous = points[index - 1];
+    if (!previous) return path;
+
+    const controlX = (previous.x + point.x) / 2;
+
+    return `${path} C ${controlX} ${previous.y}, ${controlX} ${point.y}, ${point.x} ${point.y}`;
+  }, "");
+  const firstPoint = points[0];
+  const lastPoint = points[points.length - 1];
+  if (!firstPoint || !lastPoint) return null;
+
+  const areaPath = `${linePath} L ${lastPoint.x} ${height} L ${firstPoint.x} ${height} Z`;
+
+  return (
+    <svg
+      aria-hidden="true"
+      className="text-primary pointer-events-none absolute top-5 right-5 h-13 w-32"
+      preserveAspectRatio="none"
+      viewBox={`0 0 ${width} ${height}`}
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor="currentColor" stopOpacity="0.22" />
+          <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={areaPath} fill={`url(#${gradientId})`} />
+      <path
+        d={linePath}
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeOpacity="0.62"
+        strokeWidth="2.25"
+        vectorEffect="non-scaling-stroke"
+      />
+    </svg>
+  );
+}

--- a/apps/desktop/src/hooks/queries/core/use-backup-list.ts
+++ b/apps/desktop/src/hooks/queries/core/use-backup-list.ts
@@ -30,15 +30,22 @@ export type CoreBackupItem = {
   pins: string[];
 };
 
-export function useBackupList() {
+type UseBackupListOptions = {
+  filters?: "folder" | "none";
+};
+
+export function useBackupList({
+  filters = "folder",
+}: UseBackupListOptions = {}) {
   const { profileFilter } = useProfile();
   const { queryKeys } = useQueryKey();
   const { vaultId } = useVaultId();
   const { running } = useVaultStatus();
   const { data: folder } = useFolder();
+  const useFolderFilters = filters === "folder";
 
   return useQuery({
-    queryKey: queryKeys.backup.list(folder?.id),
+    queryKey: queryKeys.backup.list(useFolderFilters ? folder?.id : "all"),
     queryFn: async () => {
       const res = await vaultApi(vaultId).get<{
         snapshots: CoreBackupItem[];
@@ -46,16 +53,18 @@ export function useBackupList() {
         uniqueCount: number;
         error?: string;
       }>("/api/v1/snapshots", {
-        params: {
-          ...profileFilter,
-          path: folder?.source.path || "",
-          all: "1",
-        },
+        params: useFolderFilters
+          ? {
+              ...profileFilter,
+              path: folder?.source.path || "",
+              all: "1",
+            }
+          : undefined,
       });
 
       return res.data.snapshots.reverse();
     },
     refetchInterval: 1000,
-    enabled: !!vaultId && !!folder && running,
+    enabled: !!vaultId && (!useFolderFilters || !!folder) && running,
   });
 }

--- a/apps/desktop/src/hooks/queries/core/use-backup-list.ts
+++ b/apps/desktop/src/hooks/queries/core/use-backup-list.ts
@@ -45,7 +45,9 @@ export function useBackupList({
   const useFolderFilters = filters === "folder";
 
   return useQuery({
-    queryKey: queryKeys.backup.list(useFolderFilters ? folder?.id : "all"),
+    queryKey: useFolderFilters
+      ? queryKeys.backup.list(folder?.id)
+      : queryKeys.backup.unfiltered(vaultId),
     queryFn: async () => {
       const res = await vaultApi(vaultId).get<{
         snapshots: CoreBackupItem[];

--- a/apps/desktop/src/hooks/queries/core/use-folder-list.ts
+++ b/apps/desktop/src/hooks/queries/core/use-folder-list.ts
@@ -89,68 +89,58 @@ export type CoreFolderItem = {
     | "FAILED";
 };
 
-async function fetchFolderList(
-  vaultId: string | undefined,
-  params?: { host: string; userName: string },
-) {
-  const res = await vaultApi(vaultId).get<{
-    sources: CoreFolderItem[];
-    error?: string;
-  }>("/api/v1/sources", {
-    params,
-  });
+type UseFolderListOptions = {
+  unfiltered?: boolean;
+};
 
-  const folders: CoreFolderItem[] = [];
-
-  for (const folder of res.data.sources) {
-    if (folder.status === "UPLOADING" && folder.upload) {
-      folder.upload.progress = !folder.upload.estimatedBytes
-        ? 0
-        : (folder.upload.hashedBytes + folder.upload.cachedBytes) /
-          folder.upload.estimatedBytes;
-    }
-
-    const id = await hashFolder({
-      hostName: folder.source.host,
-      userName: folder.source.userName,
-      path: folder.source.path,
-    });
-
-    folders.push({
-      ...folder,
-      id,
-    });
-  }
-
-  return folders;
-}
-
-export function useFolderList() {
+export function useFolderList({
+  unfiltered = false,
+}: UseFolderListOptions = {}) {
   const { profileFilter } = useProfile();
   const { queryKeys } = useQueryKey();
   const { vaultId } = useVaultId();
   const { running } = useVaultStatus();
+  const params = unfiltered ? undefined : (profileFilter ?? undefined);
 
   return useQuery({
-    queryKey: queryKeys.folder.list(vaultId, profileFilter),
+    queryKey: unfiltered
+      ? [...queryKeys.folder.all, "list", vaultId, "unfiltered"]
+      : queryKeys.folder.list(vaultId, profileFilter),
     queryFn: async () => {
-      if (!profileFilter) return null;
-      return fetchFolderList(vaultId, profileFilter);
+      if (!unfiltered && !profileFilter) return null;
+
+      const res = await vaultApi(vaultId).get<{
+        sources: CoreFolderItem[];
+        error?: string;
+      }>("/api/v1/sources", {
+        params,
+      });
+
+      const folders: CoreFolderItem[] = [];
+
+      for (const folder of res.data.sources) {
+        if (folder.status === "UPLOADING" && folder.upload) {
+          folder.upload.progress = !folder.upload.estimatedBytes
+            ? 0
+            : (folder.upload.hashedBytes + folder.upload.cachedBytes) /
+              folder.upload.estimatedBytes;
+        }
+
+        const id = await hashFolder({
+          hostName: folder.source.host,
+          userName: folder.source.userName,
+          path: folder.source.path,
+        });
+
+        folders.push({
+          ...folder,
+          id,
+        });
+      }
+
+      return folders;
     },
     refetchInterval: 1000,
-    enabled: !!vaultId && !!profileFilter && running,
-  });
-}
-
-export function useUnfilteredFolderList() {
-  const { queryKeys } = useQueryKey();
-  const { vaultId } = useVaultId();
-  const { running } = useVaultStatus();
-
-  return useQuery({
-    queryKey: [...queryKeys.folder.all, "list", vaultId, "unfiltered"],
-    queryFn: () => fetchFolderList(vaultId),
-    refetchInterval: 1000,
-    enabled: !!vaultId && running,
+    enabled: !!vaultId && (unfiltered || !!profileFilter) && running,
   });
 }

--- a/apps/desktop/src/hooks/queries/core/use-folder-list.ts
+++ b/apps/desktop/src/hooks/queries/core/use-folder-list.ts
@@ -89,6 +89,42 @@ export type CoreFolderItem = {
     | "FAILED";
 };
 
+async function fetchFolderList(
+  vaultId: string | undefined,
+  params?: { host: string; userName: string },
+) {
+  const res = await vaultApi(vaultId).get<{
+    sources: CoreFolderItem[];
+    error?: string;
+  }>("/api/v1/sources", {
+    params,
+  });
+
+  const folders: CoreFolderItem[] = [];
+
+  for (const folder of res.data.sources) {
+    if (folder.status === "UPLOADING" && folder.upload) {
+      folder.upload.progress = !folder.upload.estimatedBytes
+        ? 0
+        : (folder.upload.hashedBytes + folder.upload.cachedBytes) /
+          folder.upload.estimatedBytes;
+    }
+
+    const id = await hashFolder({
+      hostName: folder.source.host,
+      userName: folder.source.userName,
+      path: folder.source.path,
+    });
+
+    folders.push({
+      ...folder,
+      id,
+    });
+  }
+
+  return folders;
+}
+
 export function useFolderList() {
   const { profileFilter } = useProfile();
   const { queryKeys } = useQueryKey();
@@ -99,39 +135,22 @@ export function useFolderList() {
     queryKey: queryKeys.folder.list(vaultId, profileFilter),
     queryFn: async () => {
       if (!profileFilter) return null;
-
-      const res = await vaultApi(vaultId).get<{
-        sources: CoreFolderItem[];
-        error?: string;
-      }>("/api/v1/sources", {
-        params: profileFilter,
-      });
-
-      const folders: CoreFolderItem[] = [];
-
-      for (const folder of res.data.sources) {
-        if (folder.status === "UPLOADING" && folder.upload) {
-          folder.upload.progress = !folder.upload.estimatedBytes
-            ? 0
-            : (folder.upload.hashedBytes + folder.upload.cachedBytes) /
-              folder.upload.estimatedBytes;
-        }
-
-        const id = await hashFolder({
-          hostName: folder.source.host,
-          userName: folder.source.userName,
-          path: folder.source.path,
-        });
-
-        folders.push({
-          ...folder,
-          id,
-        });
-      }
-
-      return folders;
+      return fetchFolderList(vaultId, profileFilter);
     },
     refetchInterval: 1000,
     enabled: !!vaultId && !!profileFilter && running,
+  });
+}
+
+export function useUnfilteredFolderList() {
+  const { queryKeys } = useQueryKey();
+  const { vaultId } = useVaultId();
+  const { running } = useVaultStatus();
+
+  return useQuery({
+    queryKey: [...queryKeys.folder.all, "list", vaultId, "unfiltered"],
+    queryFn: () => fetchFolderList(vaultId),
+    refetchInterval: 1000,
+    enabled: !!vaultId && running,
   });
 }

--- a/apps/desktop/src/hooks/use-query-key.ts
+++ b/apps/desktop/src/hooks/use-query-key.ts
@@ -58,6 +58,11 @@ export function useQueryKey() {
       backup: {
         all: [accountId, "backup"],
         list: (folderId?: string) => [...keys.backup.all, "list", folderId],
+        unfiltered: (vaultId?: string) => [
+          ...keys.backup.all,
+          "unfiltered",
+          vaultId,
+        ],
       },
       folder: {
         all: [accountId, "folder"],

--- a/apps/desktop/src/lib/number.ts
+++ b/apps/desktop/src/lib/number.ts
@@ -10,3 +10,10 @@ export function formatInt(number: number) {
     maximumFractionDigits: 0,
   });
 }
+
+export function formatCompactInt(number: number) {
+  return number.toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+    notation: "compact",
+  });
+}

--- a/apps/desktop/src/lib/vault-stats.ts
+++ b/apps/desktop/src/lib/vault-stats.ts
@@ -1,0 +1,74 @@
+import type { CoreBackupItem } from "@desktop/hooks/queries/core/use-backup-list";
+import type { CoreFolderItem } from "@desktop/hooks/queries/core/use-folder-list";
+
+export function buildVaultStats(folders: CoreFolderItem[]) {
+  return {
+    totalSize: folders.reduce(
+      (sum, folder) => sum + (folder.lastSnapshot?.stats.totalSize || 0),
+      0,
+    ),
+    fileCount: folders.reduce(
+      (sum, folder) =>
+        sum +
+        (folder.lastSnapshot?.stats.nonCachedFiles || 0) +
+        (folder.lastSnapshot?.stats.cachedFiles || 0),
+      0,
+    ),
+    directoryCount: folders.reduce(
+      (sum, folder) => sum + (folder.lastSnapshot?.stats.dirCount || 0),
+      0,
+    ),
+  };
+}
+
+export function buildVaultStatHistory(backups: CoreBackupItem[]) {
+  const days = Array.from({ length: 30 }, (_, index) => {
+    const date = new Date();
+    date.setHours(0, 0, 0, 0);
+    date.setDate(date.getDate() - (29 - index));
+    return date;
+  });
+  const sortedBackups = [...backups]
+    .filter((backup) => backup.incomplete === undefined)
+    .sort(
+      (a, b) =>
+        new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+    );
+  const latestByRoot = new Map<string, CoreBackupItem>();
+  let backupIndex = 0;
+
+  return days.reduce(
+    (history, day) => {
+      const nextDay = new Date(day);
+      nextDay.setDate(day.getDate() + 1);
+
+      while (backupIndex < sortedBackups.length) {
+        const backup = sortedBackups[backupIndex];
+        if (!backup || new Date(backup.startTime) >= nextDay) break;
+
+        latestByRoot.set(backup.rootID, backup);
+        backupIndex += 1;
+      }
+
+      const totals = Array.from(latestByRoot.values()).reduce(
+        (sum, backup) => ({
+          totalSize: sum.totalSize + backup.summary.size,
+          fileCount: sum.fileCount + backup.summary.files,
+          directoryCount: sum.directoryCount + backup.summary.dirs,
+        }),
+        { totalSize: 0, fileCount: 0, directoryCount: 0 },
+      );
+
+      history.totalSize.push(totals.totalSize);
+      history.fileCount.push(totals.fileCount);
+      history.directoryCount.push(totals.directoryCount);
+
+      return history;
+    },
+    {
+      totalSize: [] as number[],
+      fileCount: [] as number[],
+      directoryCount: [] as number[],
+    },
+  );
+}

--- a/libs/ui/src/sparkline.tsx
+++ b/libs/ui/src/sparkline.tsx
@@ -1,14 +1,11 @@
 import { useId } from "react";
 
-type VaultStatSparklineProps = {
+type SparklineProps = {
   className?: string;
   values: number[];
 };
 
-export function VaultStatSparkline({
-  className,
-  values,
-}: VaultStatSparklineProps) {
+export function Sparkline({ className, values }: SparklineProps) {
   const gradientId = useId().replace(/:/g, "");
   const width = 130;
   const height = 52;

--- a/locales/en/vault.json
+++ b/locales/en/vault.json
@@ -356,6 +356,14 @@
         "description": "You haven't added any folders yet. Add one by pressing the button below."
       }
     },
+    "stats": {
+      "totalSize": "Total size",
+      "totalSizeDescription": "Across all latest snapshots",
+      "files": "Files",
+      "filesDescription": "Tracked in latest snapshots",
+      "devices": "Devices",
+      "devicesDescription": "Unique hosts in this vault"
+    },
     "score": {
       "category": "Excellent",
       "description": "Your backup setup is configured correctly."

--- a/locales/en/vault.json
+++ b/locales/en/vault.json
@@ -357,12 +357,12 @@
       }
     },
     "stats": {
-      "totalSize": "Total size",
+      "totalSize": "Protected data",
       "totalSizeDescription": "Across all latest snapshots",
-      "files": "Files",
+      "files": "Protected files",
       "filesDescription": "Tracked in latest snapshots",
-      "devices": "Devices",
-      "devicesDescription": "Unique hosts in this vault"
+      "directories": "Protected directories",
+      "directoriesDescription": "Tracked in latest snapshots"
     },
     "score": {
       "category": "Excellent",

--- a/locales/en/vault.json
+++ b/locales/en/vault.json
@@ -358,11 +358,8 @@
     },
     "stats": {
       "totalSize": "Protected data",
-      "totalSizeDescription": "Across all latest snapshots",
       "files": "Protected files",
-      "filesDescription": "Tracked in latest snapshots",
-      "directories": "Protected directories",
-      "directoriesDescription": "Tracked in latest snapshots"
+      "directories": "Protected directories"
     },
     "score": {
       "category": "Excellent",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add vault stats to the Overview page with 30‑day trends, replacing the old health/storage cards. Improves loading behavior and trend logic to avoid misleading signals.

- **New Features**
  - Three stat cards: Protected data, files, and directories with compact numbers.
  - 30‑day sparkline charts with up/down/flat trend and % change; hides until data loads.
  - Aggregates across all folders using unfiltered data for accurate totals.

- **Refactors**
  - Added `Sparkline` to `@blinkdisk/ui` and a reusable `VaultStatCard`.
  - Extended hooks: `useFolderList({ unfiltered })`, `useBackupList({ filters: 'none' })`, plus new query keys.
  - Added `formatCompactInt` and `vault-stats` helpers; updated `locales/en/vault.json`.

<sup>Written for commit 3169f8b02de6154dd13beb22e5d37fe89a33e877. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

