### PR TITLE
refactor(desktop): improve home vault cards

### DIFF
--- a/apps/desktop/src/components/vaults/card.tsx
+++ b/apps/desktop/src/components/vaults/card.tsx
@@ -1,6 +1,8 @@
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
 import type { ZVaultType } from "@blinkdisk/schemas/vault";
+import { cn } from "@blinkdisk/utils/class";
 import { providerIcons } from "@desktop/components/icons/providers/index";
+import { useVaultStatus } from "@desktop/hooks/queries/use-vault-status";
 import { Link } from "@tanstack/react-router";
 
 type VaultCardProps = {
@@ -10,6 +12,8 @@ type VaultCardProps = {
 export function VaultCard({ vault }: VaultCardProps) {
   const Icon = providerIcons[vault.provider];
   const { t } = useAppTranslation("vault");
+  const { status, isLoading } = useVaultStatus(vault.id);
+  const displayStatus = isLoading ? "STARTING" : (status ?? "STARTING");
 
   return (
     <Link
@@ -21,7 +25,7 @@ export function VaultCard({ vault }: VaultCardProps) {
         <div className="h-8 w-2.5 bg-linear-to-b from-neutral-200 dark:from-neutral-900/50 to-black/5 dark:to-neutral-900/20 rounded-r-[0.4rem] p-1 pl-0">
           <div className="w-full h-full rounded-r-lg bg-white dark:bg-neutral-700 border border-l-0"></div>
         </div>
-        <p className="font-semibold text-xl">{vault.name}</p>
+        <p className="truncate font-semibold text-xl">{vault.name}</p>
       </div>
       <div className="flex flex-col">
         <div className="w-full h-0.5 bg-neutral-200 dark:bg-neutral-900/50"></div>
@@ -31,9 +35,25 @@ export function VaultCard({ vault }: VaultCardProps) {
         <div className="h-8 w-2.5 bg-linear-to-b from-neutral-200 dark:from-neutral-900/50 to-black/5 dark:to-neutral-900/20 rounded-r-[0.4rem] p-1 pl-0">
           <div className="w-full h-full rounded-r-lg bg-white dark:bg-neutral-700 border border-l-0"></div>
         </div>
-        <div className="flex gap-2 items-center text-muted-foreground">
-          <Icon className="size-4" />
-          <p className="text-sm">{t(`providers.${vault.provider}.name`)}</p>
+        <div className="flex items-center gap-4 text-muted-foreground">
+          <div className="flex items-center gap-2">
+            <VaultStatusIndicator
+              loading={isLoading}
+              status={displayStatus}
+              label={t(`status.${displayStatus}`)}
+            />
+            <p
+              className={cn("text-sm", getVaultStatusTextClass(displayStatus))}
+            >
+              {t(`status.${displayStatus}`)}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Icon className="size-4" />
+            <p className="text-sm">
+              {t(`providers.${vault.provider}.shortName`)}
+            </p>
+          </div>
         </div>
       </div>
       <div className="absolute right-6">
@@ -48,6 +68,52 @@ export function VaultCard({ vault }: VaultCardProps) {
         </div>
       </div>
     </Link>
+  );
+}
+
+type VaultStatusIndicatorProps = {
+  loading: boolean;
+  status?: "SETUP" | "STARTING" | "RUNNING";
+  label: string;
+};
+
+function getVaultStatusTextClass(status?: "SETUP" | "STARTING" | "RUNNING") {
+  switch (status) {
+    case "RUNNING":
+      return "text-green-700 dark:text-green-500/85";
+    case "STARTING":
+      return "text-neutral-500 dark:text-neutral-400";
+    case "SETUP":
+      return "text-amber-600 dark:text-amber-300";
+    default:
+      return "text-neutral-500 dark:text-neutral-400";
+  }
+}
+
+function VaultStatusIndicator({
+  loading,
+  status,
+  label,
+}: VaultStatusIndicatorProps) {
+  const pending = loading || status === "STARTING";
+
+  return (
+    <div
+      aria-label={label}
+      role="img"
+      title={label}
+      className={cn(
+        "size-2 shrink-0 rounded-full ring-2 ring-black/5 transition-colors dark:ring-white/5",
+        status === "RUNNING" &&
+          "bg-green-600/90 shadow-[0_0_5px_rgb(22_163_74_/_0.45)] dark:bg-green-500/80 dark:shadow-[0_0_4px_rgb(34_197_94_/_0.35)]",
+        status === "STARTING" &&
+          "bg-neutral-400/90 shadow-[0_0_5px_rgb(115_115_115_/_0.55)] dark:bg-neutral-400/90",
+        status === "SETUP" &&
+          "bg-amber-400/90 shadow-[0_0_5px_rgb(245_158_11_/_0.55)] dark:bg-amber-300/90",
+        !status && "bg-neutral-400/80 dark:bg-neutral-500/80",
+        pending && "animate-pulse",
+      )}
+    />
   );
 }
 

--- a/apps/desktop/src/hooks/queries/use-vault-status.ts
+++ b/apps/desktop/src/hooks/queries/use-vault-status.ts
@@ -3,9 +3,10 @@ import { useQueryKey } from "@desktop/hooks/use-query-key";
 import { useVaultId } from "@desktop/hooks/use-vault-id";
 import { useQuery } from "@tanstack/react-query";
 
-export function useVaultStatus() {
+export function useVaultStatus(vaultIdOverride?: string) {
   const { queryKeys } = useQueryKey();
-  const { vaultId } = useVaultId();
+  const { vaultId: routeVaultId } = useVaultId();
+  const vaultId = vaultIdOverride ?? routeVaultId;
 
   const query = useQuery({
     queryKey: queryKeys.vault.status(vaultId),

--- a/locales/en/vault.json
+++ b/locales/en/vault.json
@@ -90,12 +90,19 @@
     "title": "Starting vault",
     "description": "Your vault is being initialized. This usually takes a few seconds."
   },
+  "status": {
+    "RUNNING": "Active",
+    "SETUP": "Setup required",
+    "STARTING": "Starting"
+  },
   "providers": {
     "CLOUDBLINK": {
-      "name": "CloudBlink"
+      "name": "CloudBlink",
+      "shortName": "CloudBlink"
     },
     "FILESYSTEM": {
       "name": "Local filesystem",
+      "shortName": "Local",
       "description": "Save to a local folder",
       "fields": {
         "path": {
@@ -107,6 +114,7 @@
     },
     "NETWORK_ATTACHED_STORAGE": {
       "name": "Network attached storage",
+      "shortName": "NAS",
       "description": "Save to a NAS device",
       "fields": {
         "path": {
@@ -118,6 +126,7 @@
     },
     "AMAZON_S3": {
       "name": "Amazon S3",
+      "shortName": "S3",
       "description": "Store on Amazon S3",
       "fields": {
         "bucket": {
@@ -152,6 +161,7 @@
     },
     "S3_COMPATIBLE": {
       "name": "S3 compatible storage",
+      "shortName": "S3",
       "description": "Use any S3-compatible service",
       "fields": {
         "bucket": {
@@ -192,6 +202,7 @@
     },
     "GOOGLE_CLOUD_STORAGE": {
       "name": "Google Cloud Storage",
+      "shortName": "GCS",
       "description": "Store on Google Cloud",
       "fields": {
         "bucket": {
@@ -210,6 +221,7 @@
     },
     "BACKBLAZE": {
       "name": "Backblaze B2",
+      "shortName": "B2",
       "description": "Store on Backblaze B2",
       "fields": {
         "bucket": {
@@ -232,6 +244,7 @@
     },
     "AZURE_BLOB_STORAGE": {
       "name": "Azure Blob Storage",
+      "shortName": "Azure",
       "description": "Store on Azure Blob Storage",
       "fields": {
         "container": {
@@ -262,6 +275,7 @@
     },
     "SFTP": {
       "name": "SFTP",
+      "shortName": "SFTP",
       "description": "Connect via SFTP",
       "fields": {
         "host": {
@@ -309,6 +323,7 @@
     },
     "RCLONE": {
       "name": "Rclone remote",
+      "shortName": "Rclone",
       "description": "Connect any Rclone remote",
       "fields": {
         "remotePath": {
@@ -323,6 +338,7 @@
     },
     "WEBDAV": {
       "name": "WebDAV",
+      "shortName": "WebDAV",
       "description": "Connect via WebDAV",
       "fields": {
         "url": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show live vault status on vault cards and switch provider labels to short names for a cleaner, more readable UI. Adds a color-coded status dot with localized text and truncates long vault names.

- **New Features**
  - Fetch and show per-card status via useVaultStatus(vault.id) (hook now accepts an optional vaultId); defaults to "STARTING" while loading.
  - Add a color dot indicator with localized label (RUNNING/STARTING/SETUP), pulsing while pending; includes aria-label and title for accessibility.
  - Display provider shortName (e.g., "S3", "GCS", "NAS"); add `status` and `shortName` translations in locales.
  - Truncate long vault names to prevent overflow.

<sup>Written for commit ac39daa58b8cae2e22ff7ac53538ee9294ed0732. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

