### PR TITLE
refactor(desktop): make folder emoji optional

### DIFF
--- a/apps/desktop/src/components/dialogs/create-folder/general.tsx
+++ b/apps/desktop/src/components/dialogs/create-folder/general.tsx
@@ -25,6 +25,12 @@ export function CreateFolderGeneral({ form }: CreateFolderGeneralProps) {
       <div className="flex flex-row items-center justify-center gap-3">
         <EmojiPicker
           locale={language}
+          clearLabel={t("emoji.clear")}
+          onEmojiClear={
+            values.emoji
+              ? () => form.setFieldValue("emoji", undefined)
+              : undefined
+          }
           onEmojiSelect={(emoji) => form.setFieldValue("emoji", emoji)}
         >
           <button type="button">
@@ -33,9 +39,15 @@ export function CreateFolderGeneral({ form }: CreateFolderGeneralProps) {
         </EmojiPicker>
         <EmojiPicker
           locale={language}
+          clearLabel={t("emoji.clear")}
+          onEmojiClear={
+            values.emoji
+              ? () => form.setFieldValue("emoji", undefined)
+              : undefined
+          }
           onEmojiSelect={(emoji) => form.setFieldValue("emoji", emoji)}
         >
-          <Button variant="secondary">{t("emoji.button")}</Button>
+          <Button variant="secondary">{t("emoji.change")}</Button>
         </EmojiPicker>
       </div>
       <form.AppField

--- a/apps/desktop/src/components/folders/general-settings.tsx
+++ b/apps/desktop/src/components/folders/general-settings.tsx
@@ -41,6 +41,12 @@ export function FolderGeneralSettings() {
           <div className="flex flex-row items-center justify-center gap-3">
             <EmojiPicker
               locale={language}
+              clearLabel={t("emoji.clear")}
+              onEmojiClear={
+                values.emoji
+                  ? () => form.setFieldValue("emoji", undefined)
+                  : undefined
+              }
               onEmojiSelect={(emoji) => form.setFieldValue("emoji", emoji)}
             >
               <button disabled={disabledContext} type="button">
@@ -49,10 +55,16 @@ export function FolderGeneralSettings() {
             </EmojiPicker>
             <EmojiPicker
               locale={language}
+              clearLabel={t("emoji.clear")}
+              onEmojiClear={
+                values.emoji
+                  ? () => form.setFieldValue("emoji", undefined)
+                  : undefined
+              }
               onEmojiSelect={(emoji) => form.setFieldValue("emoji", emoji)}
             >
               <Button disabled={disabledContext} variant="secondary">
-                {t("emoji.button")}
+                {t("emoji.change")}
               </Button>
             </EmojiPicker>
           </div>

--- a/apps/desktop/src/hooks/forms/use-create-folder-form.ts
+++ b/apps/desktop/src/hooks/forms/use-create-folder-form.ts
@@ -14,7 +14,6 @@ export function useCreateFolderForm({
   const form = useAppForm({
     defaultValues: {
       name: "",
-      emoji: "📁",
       path: "",
       ...(defaultValues || {}),
     },

--- a/apps/desktop/src/hooks/forms/use-policy-general-form.ts
+++ b/apps/desktop/src/hooks/forms/use-policy-general-form.ts
@@ -12,7 +12,7 @@ export function usePolicyGeneralForm() {
   const form = useAppForm({
     defaultValues: {
       name: policy?.defined.name,
-      emoji: policy?.defined.emoji || "📁",
+      emoji: policy?.defined.emoji || undefined,
     } as ZGeneralPolicyFormType,
     validators: {
       onSubmit: ZGeneralPolicyForm,

--- a/apps/desktop/src/lib/policy.ts
+++ b/apps/desktop/src/lib/policy.ts
@@ -123,7 +123,7 @@ export function convertPolicyFromCore(
 
   return {
     name: policy.name,
-    emoji: policy.emoji,
+    emoji: policy.emoji || undefined,
     retention: {
       latest: policy.retention?.keepLatest,
       hourly: policy.retention?.keepHourly,

--- a/apps/marketing/src/components/FolderCard.astro
+++ b/apps/marketing/src/components/FolderCard.astro
@@ -8,15 +8,21 @@ type Props = {
   class?: string;
 };
 
-const { emoji = "📁", size = "md", class: className } = Astro.props;
+const { emoji, size = "md", class: className } = Astro.props;
 
 const defaultColor = "0deg 0% 39%";
 
-const parsed = parse(emoji);
+const parsed = emoji ? parse(emoji) : [];
 const emojiUrl = parsed[0]?.url;
 const emojiCode = emojiUrl?.split("/").pop()?.replace(".svg", "") || "";
 const hue = EMOJI_TO_HUE[emojiCode as keyof typeof EMOJI_TO_HUE];
-const color = hue !== undefined ? `${hue}deg 100% 50%` : defaultColor;
+const color = emoji
+  ? hue !== undefined
+    ? `hsl(${hue}deg 100% 50%)`
+    : `hsl(${defaultColor})`
+  : `hsl(${defaultColor})`;
+const fillMix = 18;
+const strokeMix = 30;
 
 const sizeClasses = {
   lg: "size-14",
@@ -44,8 +50,8 @@ const imgSizeClasses = {
     <path
       xmlns="http://www.w3.org/2000/svg"
       d="M61 19.5V49.3923C61 51.9404 59.9817 54.3842 58.169 56.186C56.3564 57.9878 53.8979 59 51.3344 59H12.6656C10.1021 59 7.64365 57.9878 5.831 56.186C4.01834 54.3842 3 51.9404 3 49.3923V14.6077C3 12.0596 4.01834 9.61582 5.831 7.81403C7.64365 6.01224 10.1021 5 12.6656 5L22.3344 5C23.9293 4.99926 25.4998 5.27735 26.9056 5.80947C28.3115 6.3416 29.5091 7.11122 30.3917 8.04972L33.1286 10.9865C33.6305 11.5117 34.3071 11.9418 35.0992 12.2391C35.8912 12.5365 36.7745 12.6919 37.6715 12.6918H51.3344C53.8927 12.6924 56.3465 13.4093 58.1581 14.6853C59.9698 15.9614 60.9917 17.6927 61 19.5Z"
-      fill={`color-mix(in srgb, hsl(${color}) 18%, var(--background))`}
-      stroke={`color-mix(in srgb, hsl(${color}) 30%, var(--background))`}
+      fill={`color-mix(in srgb, ${color} ${fillMix}%, var(--background))`}
+      stroke={`color-mix(in srgb, ${color} ${strokeMix}%, var(--background))`}
       stroke-width="3"
       stroke-linecap="round"
       stroke-linejoin="round"></path>

--- a/libs/components/src/folder-card.tsx
+++ b/libs/components/src/folder-card.tsx
@@ -4,7 +4,7 @@ import { useMemo } from "react";
 import { parse } from "twemoji-parser";
 
 export type FolderCardProps = {
-  emoji: string | undefined;
+  emoji?: string;
   size?: number;
   theme?: "light" | "dark";
   className?: string;
@@ -13,12 +13,21 @@ export type FolderCardProps = {
 const defaultColor = "0deg 0% 39%";
 
 export function FolderCard({
-  emoji = "📁",
+  emoji,
   className,
   theme,
   size = 20,
 }: FolderCardProps) {
-  const { color, emojiUrl } = useMemo(() => {
+  const { color, emojiUrl, fillMix, strokeMix } = useMemo(() => {
+    if (!emoji) {
+      return {
+        color: `hsl(${defaultColor})`,
+        fillMix: theme === "dark" ? 34 : 18,
+        strokeMix: theme === "dark" ? 52 : 30,
+        emojiUrl: undefined,
+      };
+    }
+
     const parsed = parse(emoji);
     const url = parsed[0]?.url;
     const code = url?.split("/").pop()?.replace(".svg", "") || "";
@@ -26,8 +35,10 @@ export function FolderCard({
     return {
       color:
         hue !== undefined
-          ? `${hue}deg 100% ${!theme ? "50%" : theme === "dark" ? "65%" : "35%"}`
-          : defaultColor,
+          ? `hsl(${hue}deg 100% ${!theme ? "50%" : theme === "dark" ? "65%" : "35%"})`
+          : `hsl(${defaultColor})`,
+      fillMix: 18,
+      strokeMix: 30,
       emojiUrl: url,
     };
   }, [emoji, theme]);
@@ -50,8 +61,8 @@ export function FolderCard({
         <path
           xmlns="http://www.w3.org/2000/svg"
           d="M61 19.5V49.3923C61 51.9404 59.9817 54.3842 58.169 56.186C56.3564 57.9878 53.8979 59 51.3344 59H12.6656C10.1021 59 7.64365 57.9878 5.831 56.186C4.01834 54.3842 3 51.9404 3 49.3923V14.6077C3 12.0596 4.01834 9.61582 5.831 7.81403C7.64365 6.01224 10.1021 5 12.6656 5L22.3344 5C23.9293 4.99926 25.4998 5.27735 26.9056 5.80947C28.3115 6.3416 29.5091 7.11122 30.3917 8.04972L33.1286 10.9865C33.6305 11.5117 34.3071 11.9418 35.0992 12.2391C35.8912 12.5365 36.7745 12.6919 37.6715 12.6918H51.3344C53.8927 12.6924 56.3465 13.4093 58.1581 14.6853C59.9698 15.9614 60.9917 17.6927 61 19.5Z"
-          fill={`color-mix(in srgb, hsl(${color}) 18%, var(--background))`}
-          stroke={`color-mix(in srgb, hsl(${color}) 30%, var(--background))`}
+          fill={`color-mix(in srgb, ${color} ${fillMix}%, var(--background))`}
+          stroke={`color-mix(in srgb, ${color} ${strokeMix}%, var(--background))`}
           strokeWidth="3"
           strokeLinecap="round"
           strokeLinejoin="round"

--- a/libs/schemas/src/folder.ts
+++ b/libs/schemas/src/folder.ts
@@ -5,7 +5,7 @@ export const ZFolderEmoji = z.emoji().min(1);
 
 export const ZCreateFolderForm = z.object({
   name: ZFolderName,
-  emoji: ZFolderEmoji,
+  emoji: ZFolderEmoji.optional(),
   path: z.string().min(1),
 });
 

--- a/libs/schemas/src/policy.ts
+++ b/libs/schemas/src/policy.ts
@@ -132,7 +132,7 @@ const ZIgnoreParentPolicy = z.boolean().optional();
 
 export const ZGeneralPolicyForm = z.object({
   name: ZFolderName,
-  emoji: ZFolderEmoji,
+  emoji: ZFolderEmoji.optional(),
 });
 
 export type ZGeneralPolicyFormType = z.infer<typeof ZGeneralPolicyForm>;

--- a/libs/ui/src/emoji-picker.tsx
+++ b/libs/ui/src/emoji-picker.tsx
@@ -1,4 +1,5 @@
 import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
+import { Button } from "@ui/button";
 import { Input } from "@ui/input";
 import { Loader } from "@ui/loader";
 import { Popover, PopoverContent, PopoverTrigger } from "@ui/popover";
@@ -8,13 +9,16 @@ import {
   type Locale,
   EmojiPicker as Picker,
 } from "frimousse";
+import { EraserIcon } from "lucide-react";
 import { type ReactElement, useState } from "react";
 import { parse } from "twemoji-parser";
 
 export type EmojiPickerProps = {
   locale: string;
   children?: ReactElement;
+  clearLabel?: string;
   onEmojiSelect?: (emoji: string) => void;
+  onEmojiClear?: () => void;
 };
 
 const supportedLocales = [
@@ -51,7 +55,9 @@ const supportedLocales = [
 export function EmojiPicker({
   locale,
   children,
+  clearLabel,
   onEmojiSelect,
+  onEmojiClear,
 }: EmojiPickerProps) {
   const { t } = useAppTranslation("folder.emojiPicker");
 
@@ -68,12 +74,28 @@ export function EmojiPicker({
           locale={supportedLocales.includes(locale) ? (locale as Locale) : "en"}
         >
           <Picker.Search value={search} className="hidden" />
-          <Input
-            className="z-10 mx-2 mt-2 w-auto"
-            placeholder={t("search")}
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
+          <div className="z-10 flex items-center gap-2 p-2 pb-0">
+            <Input
+              className="w-auto flex-1"
+              placeholder={t("search")}
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+            />
+            {onEmojiClear ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                title={clearLabel}
+                onClick={() => {
+                  onEmojiClear();
+                  setIsOpen(false);
+                }}
+              >
+                <EraserIcon />
+              </Button>
+            ) : null}
+          </div>
           <Picker.Viewport className="outline-hidden relative flex-1">
             <Picker.Loading className="absolute inset-0 flex items-center justify-center text-sm text-neutral-400 dark:text-neutral-500">
               <Loader />

--- a/locales/en/folder.json
+++ b/locales/en/folder.json
@@ -7,7 +7,8 @@
       "placeholder": "Enter folder name"
     },
     "emoji": {
-      "button": "Change emoji"
+      "change": "Change emoji",
+      "clear": "Remove emoji"
     },
     "path": {
       "label": "Folder path",

--- a/locales/en/settings.json
+++ b/locales/en/settings.json
@@ -86,7 +86,8 @@
         "label": "Folder path"
       },
       "emoji": {
-        "button": "Change emoji"
+        "change": "Change emoji",
+        "clear": "Remove emoji"
       },
       "save": "Save"
     },


### PR DESCRIPTION
## Summary
- Make folder emoji optional end to end in the desktop forms and policy mapping.
- Add an in-popover clear action to the emoji picker and remove the separate external clear button.
- Update folder card fallback rendering so unset emoji uses the neutral default card treatment instead of `📁`.
- Rename the emoji picker button copy key to `emoji.change` and add `emoji.clear` labels.

## Testing
- `pnpm --filter @blinkdisk/desktop typecheck`
- `pnpm --filter @blinkdisk/marketing typecheck`
- `pnpm exec biome check` on the touched files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make folder emojis optional across the app and add a clear action inside the emoji picker. Unset emojis now render a neutral folder card instead of defaulting to 📁.

- **New Features**
  - Emoji is optional end to end: schemas (`ZCreateFolderForm`, `ZGeneralPolicyForm`), desktop forms, and policy mapping now allow `undefined` instead of forcing "📁".
  - Emoji picker adds an in-popover clear button and removes the separate clear control. New i18n keys: `emoji.change` and `emoji.clear`.
  - `FolderCard` (desktop and marketing) shows a neutral card when no emoji is set and adjusts color mixing accordingly.

- **Migration**
  - Replace `t("emoji.button")` with `t("emoji.change")`. Add `emoji.clear` in non-English locales.
  - If you relied on a default "📁", update code to handle `undefined`. Passing no `emoji` to `FolderCard` now renders the neutral style.

<sup>Written for commit 6bf06138d94cfc25c223bd533c0dbac01043b192. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

