### PR TITLE
fix(api): return empty space when missing

### DIFF
--- a/apps/api/src/routers/cloudblink.ts
+++ b/apps/api/src/routers/cloudblink.ts
@@ -23,7 +23,12 @@ export const cloudblinkRouter = router({
       .where("Space.accountId", "=", ctx.account.id)
       .executeTakeFirst();
 
-    if (!space) throw new CustomError("SPACE_NOT_FOUND");
+    if (!space)
+      return {
+        used: 0,
+        capacity: 0,
+        trialEndsAt: null,
+      };
 
     const stub = ctx.env.SPACE.getByName(space.id);
 


### PR DESCRIPTION
## Summary
- Return a zeroed space payload from `cloudblink.space` when no `Space` row exists yet
- Avoid surfacing `SPACE_NOT_FOUND` during the period before the first CloudBlink vault creates the space record

## Testing
- Biome check passed on the updated API file
- Typecheck passed for `@blinkdisk/api` and `@blinkdisk/desktop`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a zeroed space payload from `cloudblink.space` when an account has no Space yet. This avoids transient SPACE_NOT_FOUND errors during initial CloudBlink vault setup and gives clients a stable response.

<sup>Written for commit dabe21edf7fefd752f0057dda8c1065e94dc89d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

