### PR TITLE
fix(api): return null for missing space

### DIFF
--- a/apps/api/src/routers/cloudblink.ts
+++ b/apps/api/src/routers/cloudblink.ts
@@ -23,7 +23,7 @@ export const cloudblinkRouter = router({
       .where("Space.accountId", "=", ctx.account.id)
       .executeTakeFirst();
 
-    if (!space) throw new CustomError("SPACE_NOT_FOUND");
+    if (!space) return null;
 
     const stub = ctx.env.SPACE.getByName(space.id);
 

--- a/apps/desktop/src/components/accounts/home.tsx
+++ b/apps/desktop/src/components/accounts/home.tsx
@@ -2,6 +2,7 @@ import { useAppTranslation } from "@blinkdisk/hooks/use-app-translation";
 import { Button } from "@blinkdisk/ui/button";
 import { cn } from "@blinkdisk/utils/class";
 import { useSync } from "@desktop/hooks/mutations/use-sync";
+import { useSpace } from "@desktop/hooks/queries/use-space";
 import { useVaultList } from "@desktop/hooks/queries/use-vault-list";
 import { useCreateVaultDialog } from "@desktop/hooks/state/use-create-vault-dialog";
 import { useAccountId } from "@desktop/hooks/use-account-id";
@@ -17,6 +18,7 @@ export function AccountHome() {
   const { openCreateVault } = useCreateVaultDialog();
   const { mutate: sync, isPending: isSyncing } = useSync();
   const { data: vaults } = useVaultList();
+  const { data: space } = useSpace();
 
   const openCreateCloudBlink = useCallback(() => {
     openCreateVault({
@@ -30,7 +32,7 @@ export function AccountHome() {
     <div className="flex min-h-full flex-col overflow-y-auto p-6">
       <div className="mb-8 flex flex-row gap-6">
         <HealthCard isLoading={vaults === undefined} vaults={vaults} />
-        {isOnlineAccount ? (
+        {isOnlineAccount && space !== null ? (
           <StorageCard isLoading={vaults === undefined} />
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- Return `null` from `cloudblink.space` when an account has no `Space` row yet
- Hide the desktop storage card entirely once the space query resolves to `null`

## Testing
- Not run (not requested)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return `null` from the `cloudblink.space` API when an account has no space, and hide the desktop storage card in that case. This avoids an error and prevents showing storage for accounts without a space.

- **Bug Fixes**
  - API: `cloudblink.space` now returns `null` instead of `SPACE_NOT_FOUND` when no `Space` exists.
  - Desktop: `AccountHome` reads `useSpace()` and hides `StorageCard` when `space === null` for online accounts.

<sup>Written for commit 941fde3204a67d125e645ed63216f45788aff7b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinkdisk/blinkdisk/pull/243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

